### PR TITLE
add dummy data guitars list

### DIFF
--- a/backend/seed/README.md
+++ b/backend/seed/README.md
@@ -1,0 +1,54 @@
+## Steps to get seed data
+
+### download raw from musicians friend
+
+visit https://www.musiciansfriend.com/
+
+go to "categories" > "electric-guitars" , etc..
+
+open Network > XHR tab,
+
+find API request that looks similar to:
+
+```
+GET
+https://www.musiciansfriend.com/cartridges/ajax/leftNavJSON.jsp
+    ?N=100902 100511 100512 100902 500002 100511 100512
+    &pageName=category-page
+    &Nao=0
+    &recsPerPage=90
+    &Ns=bS
+```
+
+right-click, and "copy response",
+
+paste into `./xyz.raw.json`, and "beautify"
+
+view "Products"
+
+### Example Product
+
+(removed a couple keys)
+
+```json
+{
+
+    "name": "Gibson Les Paul Studio Electric Guitar",
+    "productID": "site1prodL54490",
+    "sku": "site1prod501158",
+    "defaultSkuUrl": "/guitars/gibson-les-paul-studio-electric-guitar/l54490000003000",
+    "openBoxUrl": "/guitars/open-box-gibson-les-paul-studio-electric-guitar",
+    "path": "/guitars/gibson-les-paul-studio-electric-guitar",
+    "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Studio-Electric-Guitar-Smokehouse-Burst/L54490000003000-00-220x220.jpg",
+    "itemType": "New",
+    "desc": "",
+    "rating": "9",
+    "reviews": "13",
+    "price": "$1,599.00",
+    "savings": "$150.00 (9%)",
+    "maxSavingsMSRP": "$1,749.00",
+    "minRegularPrice": "1599.0",
+    "salePrice": "1599.0",
+}
+```
+

--- a/backend/seed/acoustic.raw.json
+++ b/backend/seed/acoustic.raw.json
@@ -1,0 +1,6176 @@
+{
+
+    "params": [{
+        "param": "Ns",
+        "value": "bS"
+    }, {
+        "param": "Nao",
+        "value": "0"
+    }, {
+        "param": "pageName",
+        "value": "category-page"
+    }, {
+        "param": "N",
+        "value": "100902 100511 100512 100902 500010 100511 100512"
+    }, {
+        "param": "recsPerPage",
+        "value": "90"
+    }],
+    "hasMoreBrandFacets": true,
+
+    "pagination": [{
+        "results": "1-90",
+        "display": "90",
+        "totalResults": "265",
+        "view": "",
+        "totalCompared": "0",
+        "currentPage": "1",
+        "pages": [
+
+            {
+                "page": "1",
+                "active": false
+            }
+
+            , {
+                "page": "2",
+
+                "active": true
+
+            }
+
+            , {
+                "page": "3",
+                "active": true
+            }
+
+            , {
+                "page": "Next&gt;",
+                "active": true
+            }
+        ]
+    }],
+
+    "sortBy": [{
+            "value": "bM",
+            "name": "Best Match"
+        },
+        {
+            "value": "bS",
+            "name": "Best Sellers",
+            "selected": true
+        },
+
+        {
+            "value": "r",
+            "name": "Relevance"
+        },
+
+        {
+            "value": "oR",
+            "name": "Customer Ratings"
+        },
+
+        {
+            "value": "pHL",
+            "name": "Price - High to Low"
+        },
+        {
+            "value": "pLH",
+            "name": "Price - Low to High"
+        },
+        {
+            "value": "cD",
+            "name": "Newest First"
+        },
+        {
+            "value": "bN",
+            "name": "Brand Name A-Z"
+        }
+    ],
+    "facets": [{
+
+        "facetName": "Category",
+        "facetId": "500000",
+
+        "dimensionName": "category",
+
+        "state": "open",
+        "clearURL": "/category-page?N=100902+100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "hidden",
+
+        "selected": true,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Acoustic Guitars",
+                "facetValue": "500010",
+                "itemCount": "",
+                "seoURL": "/category-page?N=100902+100511+100512",
+
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Brands",
+        "facetId": "200000",
+
+        "dimensionName": "brand",
+
+        "state": "open",
+        "clearURL": "/acoustic-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Alvarez",
+                "facetValue": "200076",
+                "itemCount": "13",
+                "seoURL": "/acoustic-guitars/alvarez--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Beard Guitars",
+                "facetValue": "3009237",
+                "itemCount": "5",
+                "seoURL": "/acoustic-guitars/beard-guitars--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Breedlove",
+                "facetValue": "200298",
+                "itemCount": "26",
+                "seoURL": "/acoustic-guitars/breedlove--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Cole Clark",
+                "facetValue": "3006269",
+                "itemCount": "6",
+                "seoURL": "/acoustic-guitars/cole-clark--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Gibson",
+                "facetValue": "202616",
+                "itemCount": "22",
+                "seoURL": "/acoustic-guitars/gibson--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Guild",
+                "facetValue": "200903",
+                "itemCount": "17",
+                "seoURL": "/acoustic-guitars/guild--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Martin",
+                "facetValue": "202620",
+                "itemCount": "32",
+                "seoURL": "/acoustic-guitars/martin--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Rainsong",
+                "facetValue": "201708",
+                "itemCount": "6",
+                "seoURL": "/acoustic-guitars/rainsong--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Takamine",
+                "facetValue": "202079",
+                "itemCount": "30",
+                "seoURL": "/acoustic-guitars/takamine--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Taylor",
+                "facetValue": "202088",
+                "itemCount": "83",
+                "seoURL": "/acoustic-guitars/taylor--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Condition",
+        "facetId": "100901",
+
+        "dimensionName": "seeablecondition",
+
+        "state": "open",
+        "clearURL": "/acoustic-guitars?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": true,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "New",
+                "facetValue": "100902",
+                "itemCount": "",
+                "seoURL": "/acoustic-guitars?N=100511+100512",
+
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Price",
+        "facetId": "100501",
+
+        "dimensionName": "price",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "",
+
+        "selected": true,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "$1,500 - $2,000&nbsp;",
+                "facetValue": "100511",
+                "itemCount": "",
+                "seoURL": "",
+                "disabled": false,
+                "selected": true
+            },
+            {
+                "displayValue": "$2,000 - $3,000&nbsp;",
+                "facetValue": "100512",
+                "itemCount": "",
+                "seoURL": "",
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Customer Rating",
+        "facetId": "100401",
+
+        "dimensionName": "customerrating",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "<span class='stars small rate-10'></span>5 only",
+                "facetValue": "100402",
+                "itemCount": "95",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-8'></span>4 & up",
+                "facetValue": "100403",
+                "itemCount": "116",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-6'></span>3 & up",
+                "facetValue": "100404",
+                "itemCount": "121",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-4'></span>2 & up",
+                "facetValue": "100405",
+                "itemCount": "122",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-2'></span>1 & up",
+                "facetValue": "100406",
+                "itemCount": "122",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Body Type",
+        "facetId": "426100",
+
+        "dimensionName": "acoustic_body_type",
+
+        "state": "open",
+        "clearURL": "/acoustic-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Auditorium",
+                "facetValue": "4294963159",
+                "itemCount": "9",
+                "seoURL": "/acoustic-guitars/new--auditorium?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Classical",
+                "facetValue": "3015009",
+                "itemCount": "3",
+                "seoURL": "/acoustic-guitars/new--classical?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Concert",
+                "facetValue": "4294963153",
+                "itemCount": "19",
+                "seoURL": "/acoustic-guitars/new--concert?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Dreadnought",
+                "facetValue": "4294963160",
+                "itemCount": "48",
+                "seoURL": "/acoustic-guitars/new--dreadnought?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Folk",
+                "facetValue": "4294963151",
+                "itemCount": "2",
+                "seoURL": "/acoustic-guitars/new--folk?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Grand Auditorium",
+                "facetValue": "4294963154",
+                "itemCount": "32",
+                "seoURL": "/acoustic-guitars/new--grand-auditorium?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Grand Concert",
+                "facetValue": "4294963150",
+                "itemCount": "35",
+                "seoURL": "/acoustic-guitars/new--grand-concert?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Grand Performance",
+                "facetValue": "3010298",
+                "itemCount": "5",
+                "seoURL": "/acoustic-guitars/new--grand-performance?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Grand Symphony",
+                "facetValue": "4294962486",
+                "itemCount": "1",
+                "seoURL": "/acoustic-guitars/new--grand-symphony?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Jumbo",
+                "facetValue": "4294963152",
+                "itemCount": "10",
+                "seoURL": "/acoustic-guitars/new--jumbo?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mini Jumbo",
+                "facetValue": "4294963141",
+                "itemCount": "2",
+                "seoURL": "/acoustic-guitars/new--mini-jumbo?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Orchestra",
+                "facetValue": "4294963147",
+                "itemCount": "4",
+                "seoURL": "/acoustic-guitars/new--orchestra?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Parlor",
+                "facetValue": "4294963163",
+                "itemCount": "6",
+                "seoURL": "/acoustic-guitars/new--parlor?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Performance Level",
+        "facetId": "407300",
+
+        "dimensionName": "performance_level",
+
+        "state": "open",
+        "clearURL": "/acoustic-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Beginner",
+                "facetValue": "4294966586",
+                "itemCount": "1",
+                "seoURL": "/acoustic-guitars/new--beginner?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Intermediate",
+                "facetValue": "4294966673",
+                "itemCount": "5",
+                "seoURL": "/acoustic-guitars/new--intermediate?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Professional",
+                "facetValue": "4294966659",
+                "itemCount": "100",
+                "seoURL": "/acoustic-guitars/new--professional?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Acoustic-Electric",
+        "facetId": "425600",
+
+        "dimensionName": "acoustic-electric",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Yes",
+                "facetValue": "4294963170",
+                "itemCount": "119",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "No",
+                "facetValue": "4294963169",
+                "itemCount": "148",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Color",
+        "facetId": "402500",
+
+        "dimensionName": "color",
+
+        "state": "open",
+        "clearURL": "/acoustic-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Black",
+                "facetValue": "4294967023",
+                "itemCount": "9",
+                "seoURL": "/acoustic-guitars/new--black?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Blue",
+                "facetValue": "4294967027",
+                "itemCount": "1",
+                "seoURL": "/acoustic-guitars/new--blue?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Brown",
+                "facetValue": "4294966739",
+                "itemCount": "1",
+                "seoURL": "/acoustic-guitars/new--brown?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Burst or Fade",
+                "facetValue": "4294962114",
+                "itemCount": "61",
+                "seoURL": "/acoustic-guitars/new--burst-or-fade?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Clear",
+                "facetValue": "3018160",
+                "itemCount": "1",
+                "seoURL": "/acoustic-guitars/new--clear?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Multi-Colored",
+                "facetValue": "4294967020",
+                "itemCount": "1",
+                "seoURL": "/acoustic-guitars/new--multi-colored?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Natural",
+                "facetValue": "4294966891",
+                "itemCount": "111",
+                "seoURL": "/acoustic-guitars/new--natural?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Red",
+                "facetValue": "4294967026",
+                "itemCount": "2",
+                "seoURL": "/acoustic-guitars/new--red?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Model",
+        "facetId": "3016952",
+
+        "dimensionName": "model",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "15",
+                "facetValue": "3018814",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "16",
+                "facetValue": "3018826",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "17",
+                "facetValue": "3018825",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "21",
+                "facetValue": "3018819",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "214",
+                "facetValue": "3018821",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "224",
+                "facetValue": "3018813",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "312",
+                "facetValue": "3018815",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "314",
+                "facetValue": "3018789",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "317",
+                "facetValue": "3018816",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "322",
+                "facetValue": "3018809",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "324",
+                "facetValue": "3018786",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "362",
+                "facetValue": "3019316",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "414",
+                "facetValue": "3019204",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "512",
+                "facetValue": "3019280",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "514",
+                "facetValue": "3018838",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "517",
+                "facetValue": "3018757",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "522",
+                "facetValue": "3018837",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "524",
+                "facetValue": "3018835",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "714",
+                "facetValue": "3018768",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "717",
+                "facetValue": "3018787",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "T11",
+                "facetValue": "3017046",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "T12",
+                "facetValue": "3017327",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "T5",
+                "facetValue": "3019032",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "T6",
+                "facetValue": "3019036",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Yairi",
+                "facetValue": "3017248",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Artist Model",
+        "facetId": "3016869",
+
+        "dimensionName": "artist_model",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Jason Mraz",
+                "facetValue": "3016898",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Number of Strings",
+        "facetId": "406800",
+
+        "dimensionName": "number_of_strings",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "6 String",
+                "facetValue": "4294966899",
+                "itemCount": "250",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "12 String",
+                "facetValue": "4294966596",
+                "itemCount": "15",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Left- or Right-Handed",
+        "facetId": "407000",
+
+        "dimensionName": "orientation",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Left Handed",
+                "facetValue": "4294966611",
+                "itemCount": "20",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Right Handed",
+                "facetValue": "4294966905",
+                "itemCount": "245",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Country of Origin",
+        "facetId": "402700",
+
+        "dimensionName": "country_of_origin",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Bulgaria",
+                "facetValue": "4294965503",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Canada",
+                "facetValue": "4294966526",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "China",
+                "facetValue": "4294966892",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Japan",
+                "facetValue": "4294966605",
+                "itemCount": "31",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mexico",
+                "facetValue": "4294966600",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "South Korea",
+                "facetValue": "4294966902",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Spain",
+                "facetValue": "4294966590",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "United States",
+                "facetValue": "4294966675",
+                "itemCount": "156",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Guitar Size",
+        "facetId": "421500",
+
+        "dimensionName": "guitar_size",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "4/4",
+                "facetValue": "4294966598",
+                "itemCount": "139",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Top Material",
+        "facetId": "3012157",
+
+        "dimensionName": "top_material",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Cedar",
+                "facetValue": "3012168",
+                "itemCount": "9",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Koa",
+                "facetValue": "3012160",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mahogany",
+                "facetValue": "3012159",
+                "itemCount": "39",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Maple",
+                "facetValue": "3012161",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Nato",
+                "facetValue": "3012163",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Redwood",
+                "facetValue": "3012164",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Spruce",
+                "facetValue": "3012166",
+                "itemCount": "120",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Other hardwood",
+                "facetValue": "3013053",
+                "itemCount": "13",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Back & Side Material",
+        "facetId": "3012142",
+
+        "dimensionName": "back___side_material",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Acacia",
+                "facetValue": "3012145",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Cherry",
+                "facetValue": "3012148",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Koa",
+                "facetValue": "3012155",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mahogany",
+                "facetValue": "3012151",
+                "itemCount": "53",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Maple",
+                "facetValue": "3012154",
+                "itemCount": "9",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Nato",
+                "facetValue": "3012153",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Ovangkol",
+                "facetValue": "3015192",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Redwood",
+                "facetValue": "3012146",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Rosewood",
+                "facetValue": "3012152",
+                "itemCount": "44",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Sapele",
+                "facetValue": "3012149",
+                "itemCount": "20",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Walnut",
+                "facetValue": "3012150",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Other hardwood",
+                "facetValue": "3014233",
+                "itemCount": "10",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Fingerboard Material",
+        "facetId": "3012709",
+
+        "dimensionName": "fingerboard_material",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Ebony",
+                "facetValue": "3012711",
+                "itemCount": "153",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Rosewood",
+                "facetValue": "3012714",
+                "itemCount": "39",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Walnut",
+                "facetValue": "3012715",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Composite Material",
+                "facetValue": "3015131",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Accessories Included",
+        "facetId": "3016071",
+
+        "dimensionName": "accessories_included",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Case",
+                "facetValue": "3016073",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Gig bag",
+                "facetValue": "3016077",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Hardshell case",
+                "facetValue": "3016072",
+                "itemCount": "138",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Number of Frets",
+        "facetId": "3016006",
+
+        "dimensionName": "number_of_frets",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "12",
+                "facetValue": "3016012",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "17",
+                "facetValue": "3016007",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "18",
+                "facetValue": "3016008",
+                "itemCount": "16",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "19",
+                "facetValue": "3016016",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "20",
+                "facetValue": "3016010",
+                "itemCount": "130",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "20",
+                "facetValue": "3021749",
+                "itemCount": "130",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "21",
+                "facetValue": "3016017",
+                "itemCount": "9",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "22",
+                "facetValue": "3016020",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Nut Width",
+        "facetId": "3016021",
+
+        "dimensionName": "nut_width",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "1.65 in. (42 mm)",
+                "facetValue": "3016026",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.656 in. (42 mm)",
+                "facetValue": "3016051",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.675 in. (42.5 mm)",
+                "facetValue": "3016043",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.68 in. (42.67 mm)",
+                "facetValue": "3016064",
+                "itemCount": "9",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.687 in. (42.8 mm)",
+                "facetValue": "3016022",
+                "itemCount": "10",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.69 in. (43 mm)",
+                "facetValue": "3016024",
+                "itemCount": "12",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.725 in. (43.8 mm)",
+                "facetValue": "3016066",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.73 in. (43.82 mm)",
+                "facetValue": "3016052",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.75 in. (44.45 mm)",
+                "facetValue": "3016055",
+                "itemCount": "118",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.77 in. (45 mm)",
+                "facetValue": "3016063",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.81 in. (46 mm)",
+                "facetValue": "3016035",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.84 in. (46.8 mm)",
+                "facetValue": "3016059",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.87 in. (47.49 mm)",
+                "facetValue": "3016028",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.875 in. (47.62 mm)",
+                "facetValue": "3016032",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "2 in. (52 mm)",
+                "facetValue": "3016034",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Series",
+        "facetId": "3017404",
+
+        "dimensionName": "series_new",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "200 Series",
+                "facetValue": "3017501",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "300 Series",
+                "facetValue": "3017497",
+                "itemCount": "24",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "400 Series",
+                "facetValue": "3017503",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "500 Series",
+                "facetValue": "3017407",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "700 Series",
+                "facetValue": "3017578",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Builder&#039;s Edition",
+                "facetValue": "3017506",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Frontier",
+                "facetValue": "3017474",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Historic",
+                "facetValue": "3017580",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Oregon",
+                "facetValue": "3017575",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Premier",
+                "facetValue": "3017528",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Prewar",
+                "facetValue": "3017563",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Savings & Specials",
+        "facetId": "100201",
+
+        "dimensionName": "deals",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Best Sellers",
+                "facetValue": "100206",
+                "itemCount": "65",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "On Sale",
+                "facetValue": "100202",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Price Drop",
+                "facetValue": "100203",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "New Arrivals",
+        "facetId": "100301",
+
+        "dimensionName": "newarrivals",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "New",
+                "facetValue": "100302",
+                "itemCount": "11",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Pre-Order",
+                "facetValue": "100303",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Financing",
+        "facetId": "3000000",
+
+        "dimensionName": "financing",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "48 Month Financing",
+                "facetValue": "3014271",
+                "itemCount": "232",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "In Stock",
+        "facetId": "3000002",
+
+        "dimensionName": "in stock",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Now In Stock",
+                "facetValue": "3024872",
+                "itemCount": "151",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }],
+    "categories": [
+
+        {
+            "displayName": "New 12 String Acoustic Guitars",
+            "catId": "site1ABB",
+            "dimVal": "500012",
+            "url": "/12-string-acoustic-guitars/new?N=100511+100512",
+            "count": "15"
+        },
+        {
+            "displayName": "New 6 String Acoustic Guitars",
+            "catId": "site1ABA",
+            "dimVal": "500011",
+            "url": "/6-string-acoustic-guitars/new?N=100511+100512",
+            "count": "232"
+        },
+        {
+            "displayName": "New Acoustic-Electric Guitars",
+            "catId": "site1ABN",
+            "dimVal": "3013917",
+            "url": "/acoustic-electric-guitars/new?N=100511+100512",
+            "count": "214"
+        },
+        {
+            "displayName": "New Left-Handed Acoustic Guitars",
+            "catId": "site1ABM",
+            "dimVal": "500015",
+            "url": "/left-handed-acoustic-guitars/new?N=100511+100512",
+            "count": "20"
+        }
+    ],
+    "products": [
+
+        {
+
+            "name": "Martin Special 16 Style Rosewood Dreadnought Acoustic-Electric Guitar",
+            "productID": "site1prodL73540",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-d-16e-rosewood-dreadnought-acoustic-electric-guitar/l73540000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-d-16e-rosewood-dreadnought-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Special-16-Style-Rosewood-Dreadnought-Acoustic-Electric-Guitar-Natural/L73540000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "14",
+            "price": "$1,749.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1749.0",
+            "salePrice": "1749.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$37&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-d-16e-rosewood-dreadnought-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Martin D-18 Standard Dreadnought Acoustic Guitar",
+            "productID": "site1prodH83179",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-d-18-standard-dreadnought-acoustic-guitar/h83179000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-d-18-standard-dreadnought-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/D-18-Standard-Dreadnought-Acoustic-Guitar-Natural/H83179000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "26",
+            "price": "$2,599.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2599.0",
+            "salePrice": "2599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$55&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-d-18-standard-dreadnought-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Martin GPC Special 16 Style Rosewood Grand Performance Acoustic-Electric Guitar",
+            "productID": "site1prodL72386",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-gpc-special-16-style-rosewood-grand-performance-acoustic-electric-guitar/l72386000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-gpc-16e-special-16-style-rosewood-grand-performance-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/GPC-Special-16-Style-Rosewood-Grand-Performance-Acoustic-Electric-Guitar-Ambertone/L72386000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "6",
+            "price": "$1,849.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1849.0",
+            "salePrice": "1849.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$39&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-gpc-16e-special-16-style-rosewood-grand-performance-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Martin SC-13E Acoustic-Electric Guitar",
+            "productID": "site1prodL73449",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-s-series-sc-13e-acoustic-electric-guitar/l73449000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-s-series-sc-13e-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/SC-13E-Acoustic-Electric-Guitar-Natural/L73449000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "14",
+            "price": "$1,599.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-s-series-sc-13e-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Martin Special Grand Performance Cutaway 15ME Streetmaster Style Acoustic-Electric Guitar",
+            "productID": "site1prodL40683",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-special-grand-performance-cutaway-15me-streetmaster-style-acoustic-electric-guitar/l40683000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-special-grand-performance-cutaway-15me-streetmaster-style-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Special-Grand-Performance-Cutaway-15ME-Streetmaster-Style-Acoustic-Electric-Guitar-Natural/L40683000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "4",
+            "price": "$1,649.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "10% off w/ guitarfest",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1649.0",
+            "salePrice": "1649.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$35&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-special-grand-performance-cutaway-15me-streetmaster-style-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 414ce V-Class Special-Edition Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL26331",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-acoustic-electric-guitar/l26331000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-V-Class-Special-Edition-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L26331000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "5",
+            "price": "$2,899.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2899.0",
+            "salePrice": "2899.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$61&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 714ce V-Class Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL18229",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-714ce-v-class-grand-auditorium-acoustic-electric-guitar/l18229000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-714ce-v-class-grand-auditorium-acoustic-electric-guitar/l18229000001000",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/714ce-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L18229000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "6",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/taylor-714ce-v-class-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Martin D-28 Standard Dreadnought Acoustic Guitar",
+            "productID": "site1prodK40776",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-d-28-standard-dreadnought-acoustic-guitar/k40776000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-d-28-standard-dreadnought-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/D-28-Standard-Dreadnought-Acoustic-Guitar-Natural/K40776000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "91",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-d-28-standard-dreadnought-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Takamine EF381SC 12-String Acoustic-Electric Cutaway Guitar",
+            "productID": "site1prod516328",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/takamine-ef381sc-12-string-acoustic-electric-cutaway-guitar/516328000000000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/takamine-ef381sc-12-string-acoustic-electric-cutaway-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/EF381SC-12-String-Acoustic-Electric-Cutaway-Guitar/516328000000000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "A made-for-the-stage, glossy black 12-stringer!",
+            "rating": "10",
+            "reviews": "32",
+            "price": "$1,599.99",
+
+            "savings": "$556.00 (26%)",
+
+            "maxSavingsMSRP": "$2,155.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.99",
+            "salePrice": "1599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/takamine-ef381sc-12-string-acoustic-electric-cutaway-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Acoustasonic Telecaster Ebony Fingerboard Acoustic-Electric Guitar",
+            "productID": "site1prodL83638",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-acoustasonic-telecaster-ebony-fingerboard-acoustic-electric-guitar/l83638000003000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-acoustasonic-telecaster-ebony-fingerboard-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Acoustasonic-Telecaster-Ebony-Fingerboard-Acoustic-Electric-Guitar-Black/L83638000003000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,999.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "7",
+                "productUrl": "/guitars/fender-acoustasonic-telecaster-ebony-fingerboard-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Acoustasonic Jazzmaster Acoustic-Electric Guitar",
+            "productID": "site1prodL81319",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-acoustasonic-jazzmaster-acoustic-electric-guitar/l81319000005000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-acoustasonic-jazzmaster-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Acoustasonic-Jazzmaster-Acoustic-Electric-Guitar-Arctic-White/L81319000005000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "3",
+            "price": "$1,999.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "5",
+                "productUrl": "/guitars/fender-acoustasonic-jazzmaster-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Martin Special 18 Style VTS Dreadnought Acoustic Guitar",
+            "productID": "site1prodL75239",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-special-18-style-vts-dreadnought-acoustic-guitar/l75239000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-special-18-style-vts-dreadnought-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Special-18-Style-VTS-Dreadnought-Acoustic-Guitar-Natural/L75239000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "4",
+            "price": "$2,499.99",
+
+            "regularPrice": "$2,849.99",
+
+            "savings": "$350.00 (12%)",
+
+            "maxSavingsMSRP": "$2,849.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Sale",
+            "stickerClass": "stickerEmphasis",
+            "compared": false,
+            "onsale": "true",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2849.99",
+            "salePrice": "2499.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$53&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-special-18-style-vts-dreadnought-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Acoustasonic Stratocaster Acoustic-Electric Guitar",
+            "productID": "site1prodL72102",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-acoustasonic-stratocaster-acoustic-electric-guitar/l72102000005000",
+
+            "openBoxUrl": "/guitars/open-box-fender-acoustasonic-stratocaster-acoustic-electric-guitar",
+
+            "path": "/guitars/fender-acoustasonic-stratocaster-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Acoustasonic-Stratocaster-Acoustic-Electric-Guitar-Trans-Sonic-Blue/L72102000005000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$1,999.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "5",
+                "productUrl": "/guitars/fender-acoustasonic-stratocaster-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Martin DSS-17 Whiskey Sunset Dreadnought Acoustic Guitar",
+            "productID": "site1prodL47495",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-dss-17-whiskey-sunset-dreadnought-acoustic-guitar/l47495000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-dss-17-whiskey-sunset-dreadnought-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/DSS-17-Whiskey-Sunset-Dreadnought-Acoustic-Guitar-Natural/L47495000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "6",
+            "price": "$1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-dss-17-whiskey-sunset-dreadnought-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson J-45 Standard Acoustic-Electric Guitar",
+            "productID": "site1prodL28131",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-j-45-standard-acoustic-electric-guitar/l28131000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-j-45-standard-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/J-45-Standard-Acoustic-Electric-Guitar-Vintage-Sunburst/L28131000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,849.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2849.0",
+            "salePrice": "2849.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$60&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-j-45-standard-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 314ce V-Class Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL26669",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-314ce-v-class-grand-auditorium-acoustic-electric-guitar/l26669000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-314ce-v-class-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/314ce-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L26669000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "8",
+            "price": "$1,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-314ce-v-class-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor T5z Pro Acoustic-Electric Guitar",
+            "productID": "site1prodJ03787",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-t5z-pro-acoustic-electric-guitar/j03787000002000",
+
+            "openBoxUrl": "/guitars/open-box-taylor-t5z-pro-acoustic-electric-guitar",
+
+            "path": "/guitars/taylor-t5z-pro-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/T5z-Pro-Acoustic-Electric-Guitar-Pacific-Blue/J03787000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "6",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "5",
+                "productUrl": "/guitars/taylor-t5z-pro-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Guild M-20 Concert Acoustic Guitar",
+            "productID": "site1prodJ37917",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/guild-m-20-concert-acoustic-guitar/j37917000002000",
+
+            "openBoxUrl": "/guitars/open-box-guild-m-20-concert-acoustic-guitar",
+
+            "path": "/guitars/guild-m-20-concert-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/M-20-Concert-Acoustic-Guitar-Vintage-Sunburst/J37917000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "12",
+            "price": "Starting&nbsp;at $1,599.00",
+
+            "savings": "$426.00 (20%)",
+
+            "maxSavingsMSRP": "$2,125.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/guild-m-20-concert-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "The Loar LH-700 Archtop Acoustic Guitar",
+            "productID": "site1prod581071",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/the-loar-lh-700-archtop-acoustic-guitar/581071000015000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/the-loar-lh-700-archtop-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/LH-700-Archtop-Acoustic-Guitar-Vintage-Sunburst/581071000015000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "Hand-carved select tonewoods for the professional jazz guitarist.",
+            "rating": "8",
+            "reviews": "17",
+            "price": "$1,749.99",
+
+            "savings": "$584.00 (25%)",
+
+            "maxSavingsMSRP": "$2,333.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1749.99",
+            "salePrice": "1749.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$37&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/the-loar-lh-700-archtop-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Martin 17 Series 000-17 Auditorium Acoustic Guitar",
+            "productID": "site1prodJ31119",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-17-series-000-17-auditorium-acoustic-guitar/j31119000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-17-series-000-17-auditorium-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/17-Series-000-17-Auditorium-Acoustic-Guitar-Whiskey-Sunset/J31119000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "11",
+            "price": "$1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-17-series-000-17-auditorium-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Guild D-20 Dreadnought Acoustic Guitar",
+            "productID": "site1prodJ37926",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/guild-d-20-dreadnought-acoustic-guitar/j37926000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/guild-d-20-dreadnought-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/D-20-Dreadnought-Acoustic-Guitar-Natural/J37926000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "9",
+            "price": "Starting&nbsp;at $1,599.00",
+
+            "savings": "$401.00 (20%)",
+
+            "maxSavingsMSRP": "$2,000.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/guild-d-20-dreadnought-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Rainsong CO-WS1000N2 Concert Series Graphite Acoustic-Electric Guitar",
+            "productID": "site1prod581063",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/rainsong-co-ws1000n2-concert-series-graphite-acoustic-electric-guitar/581063000010000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/rainsong-co-ws1000n2-concert-series-graphite-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/CO-WS1000N2-Concert-Series-Graphite-Acoustic-Electric-Guitar-Carbon/581063000010000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "This concert-size guitar boasts RainSong&#39;s lightest unidirectional carbon top to mimic the tight grain of a...",
+            "rating": "9",
+            "reviews": "7",
+            "price": "$2,999.00",
+
+            "savings": "$333.00 (10%)",
+
+            "maxSavingsMSRP": "$3,332.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Private Reserve",
+            "stickerClass": "sticker-inverse",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/rainsong-co-ws1000n2-concert-series-graphite-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor GTe Blacktop Grand Theater Acoustic-Electric Guitar",
+            "productID": "site1prodL92120",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-gte-blacktop-grand-theater-acoustic-electric-guitar/l92120000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-gte-blacktop-grand-theater-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/GTe-Blacktop-Grand-Theater-Acoustic-Electric-Guitar-Black/L92120000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.0",
+            "salePrice": "1799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-gte-blacktop-grand-theater-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor AD27e Flametop Grand Pacific Acoustic-Electric Guitar",
+            "productID": "site1prodL92038",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-ad27e-flametop-grand-pacific-acoustic-electric-guitar/l92038000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-ad27e-flametop-grand-pacific-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/AD27e-Flametop-Grand-Pacific-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L92038000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,199.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2199.0",
+            "salePrice": "2199.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-ad27e-flametop-grand-pacific-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "McPherson Carbon Series Touring With Black Hardware Acoustic-Electric Guitar",
+            "productID": "site1prodL91962",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/mcpherson-carbon-series-touring-with-black-hardware-acoustic-electric-guitar/l91962000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/mcpherson-carbon-series-touring-with-black-hardware-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Carbon-Series-Touring-With-Black-Hardware-Acoustic-Electric-Guitar-Honeycomb-Top/L91962000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,699.00",
+
+            "savings": "$200.00 (7%)",
+
+            "maxSavingsMSRP": "$2,899.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "New",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2699.0",
+            "salePrice": "2699.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/mcpherson-carbon-series-touring-with-black-hardware-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Martin SC-13E Special Road Series Acoustic-Electric Guitar",
+            "productID": "site1prodL90904",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-sc-13e-special-road-series-acoustic-electric-guitar/l90904000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-sc-13e-special-road-series-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/SC-13E-Special-Road-Series-Acoustic-Electric-Guitar-Sunburst/L90904000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "Starting&nbsp;at $1,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.0",
+            "salePrice": "1799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/martin-sc-13e-special-road-series-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson J-45 Rosewood Acoustic-Electric Guitar",
+            "productID": "site1prodL88184",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-j-45-rosewood-acoustic-electric-guitar/l88184000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-j-45-rosewood-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/J-45-Rosewood-Acoustic-Electric-Guitar-Amber-Burst/L88184000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,999.00",
+
+            "savings": "$400.00 (12%)",
+
+            "maxSavingsMSRP": "$3,399.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-j-45-rosewood-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 314ce-K Special Edition Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL83875",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-314ce-k-special-edition-grand-auditorium-acoustic-electric-guitar/l83875000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-314ce-k-special-edition-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/314ce-K-Special-Edition-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L83875000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-314ce-k-special-edition-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Alvarez JYM80CE YAIRI MASTERWORKS SOLID SPRUCE JUMBO",
+            "productID": "site1prodL83823",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/alvarez-jym80ce-yairi-masterworks-solid-spruce-jumbo/l83823000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/alvarez-jym80ce-yairi-masterworks-solid-spruce-jumbo",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/JYM80CE-YAIRI-MASTERWORKS-SOLID-SPRUCE-JUMBO-Natural/L83823000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,899.00",
+
+            "savings": "$1,400.00 (33%)",
+
+            "maxSavingsMSRP": "$4,299.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2899.0",
+            "salePrice": "2899.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$61&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/alvarez-jym80ce-yairi-masterworks-solid-spruce-jumbo"
+            }
+        },
+        {
+
+            "name": "Gibson J-45 Studio Walnut Acoustic-Electric Guitar",
+            "productID": "site1prodL76032",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-j-45-studio-walnut-acoustic-electric-guitar/l76032000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-j-45-studio-walnut-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/J-45-Studio-Walnut-Acoustic-Electric-Guitar-Antique-Natural/L76032000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-j-45-studio-walnut-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Breedlove USA Concertina E Mahogany Acoustic/Electric Guitar",
+            "productID": "site1prodL72181",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/breedlove-usa-concertina-e-mahogany-acoustic-electric-guitar/l72181000001000",
+
+            "openBoxUrl": "/guitars/open-box-breedlove-usa-concertina-e-mahogany-acoustic-electric-guitar",
+
+            "path": "/guitars/breedlove-breedlove-usa-concertina-e-mahogany-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/USA-Concertina-E-Mahogany-Acoustic-Electric-Guitar-Natural/L72181000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$1,699.00",
+
+            "savings": "$566.00 (25%)",
+
+            "maxSavingsMSRP": "$2,265.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/breedlove-breedlove-usa-concertina-e-mahogany-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 214ce-K DLX Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL48323",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-214ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l48323000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-214ce-k-dlx-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/214ce-K-DLX-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L48323000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "26",
+            "price": "$1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-214ce-k-dlx-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 224ce-K DLX Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL47472",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-224ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l47472000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-224ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l47472",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/224ce-K-DLX-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L47472000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "37",
+            "price": "$1,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.0",
+            "salePrice": "1799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-224ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l47472"
+            }
+        },
+        {
+
+            "name": "Takamine PTU241C Dreadnought Acoustic-Electric Guitar",
+            "productID": "site1prodL30110",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/takamine-ptu241c-dreadnought-acoustic-electric-guitar/l30110000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/takamine-ptu241c-dreadnought-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/PTU241C-Dreadnought-Acoustic-Electric-Guitar-Tobacco-Sunburst/L30110000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "5",
+            "price": "$1,549.99",
+
+            "savings": "$1,026.00 (40%)",
+
+            "maxSavingsMSRP": "$2,575.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1549.99",
+            "salePrice": "1549.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$33&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/takamine-ptu241c-dreadnought-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Rainsong Concert Series Jumbo Acoustic-Electric Guitar",
+            "productID": "site1prodH88047",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/rainsong-concert-series-jumbo-acoustic-electric-guitar/h88047000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/rainsong-concert-series-jumbo-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Concert-Series-Jumbo-Acoustic-Electric-Guitar-Graphite/H88047000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Private Reserve",
+            "stickerClass": "sticker-inverse",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/rainsong-concert-series-jumbo-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Rainsong CO-DR1000N2 Dreadnought Acoustic-Electric Guitar",
+            "productID": "site1prodH88043",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/rainsong-co-dr1000n2-dreadnought-acoustic-electric-guitar/h88043000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/rainsong-co-dr1000n2-dreadnought-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/CO-DR1000N2-Dreadnought-Acoustic-Electric-Guitar-Graphite/H88043000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Private Reserve",
+            "stickerClass": "sticker-inverse",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/rainsong-co-dr1000n2-dreadnought-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Takamine JJ325SRC John Jorgenson Signature Acoustic-Electric",
+            "productID": "site1prod516323",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/takamine-jj325src-john-jorgenson-signature-acoustic-electric/516323000000000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/takamine-jj325src-john-jorgenson-signature-acoustic-electric",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/JJ325SRC-John-Jorgenson-Signature-Acoustic-Electric/516323000000000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "8",
+            "price": "$1,899.99",
+
+            "savings": "$641.00 (25%)",
+
+            "maxSavingsMSRP": "$2,540.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1899.99",
+            "salePrice": "1899.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$40&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/takamine-jj325src-john-jorgenson-signature-acoustic-electric"
+            }
+        },
+        {
+
+            "name": "Taylor GTe Mahogany Grand Theater Acoustic-Electric Guitar",
+            "productID": "site1prodL92121",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-gte-mahogany-grand-theater-acoustic-electric-guitar/l92121000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-gte-mahogany-grand-theater-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/GTe-Mahogany-Grand-Theater-Acoustic-Electric-Guitar-Urban-Sienna/L92121000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-gte-mahogany-grand-theater-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Breedlove Oregon Concert Sable CE Myrtlewood LTD Acoustic Electric Guitar",
+            "productID": "site1prodL90987",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/breedlove-oregon-concert-sable-ce-myrtlewood-ltd-acoustic-electric-guitar/l90987000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/breedlove-oregon-concert-sable-ce-myrtlewood-ltd-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Oregon-Concert-Sable-CE-Myrtlewood-LTD-Acoustic-Electric-Guitar-Sable-Burst/L90987000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,899.00",
+
+            "savings": "$966.00 (25%)",
+
+            "maxSavingsMSRP": "$3,865.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2899.0",
+            "salePrice": "2899.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$61&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/breedlove-oregon-concert-sable-ce-myrtlewood-ltd-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor AD22e American Dream Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL88695",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-ad22e-american-dream-grand-concert-acoustic-electric-guitar/l88695000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-ad22e-american-dream-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/AD22e-American-Dream-Grand-Concert-Acoustic-Electric-Guitar-Urban-Sienna/L88695000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-ad22e-american-dream-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Generation Collection G-Writer EC Acoustic-Electric Guitar",
+            "productID": "site1prodL86797",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-generation-collection-g-writer-ec-acoustic-electric-guitar/l86797000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-generation-collection-g-writer-ec-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Generation-Collection-G-Writer-EC-Acoustic-Electric-Guitar-Natural/L86797000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$1,599.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-generation-collection-g-writer-ec-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Generation Collection G-200 EC Acoustic-Electric Guitar",
+            "productID": "site1prodL86796",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-generation-collection-g-200-ec-acoustic-electric-guitar/l86796000001000",
+
+            "openBoxUrl": "/guitars/open-box-gibson-generation-collection-g-200-ec-acoustic-electric-guitar",
+
+            "path": "/guitars/gibson-generation-collection-g-200-ec-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Generation-Collection-G-200-EC-Acoustic-Electric-Guitar-Natural/L86796000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-generation-collection-g-200-ec-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Beard Guitars Deco Phonic Highball Acoustic Guitar",
+            "productID": "site1prodL84967",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/beard-guitars-deco-phonic-highball-acoustic-guitar/l84967000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/beard-guitars-deco-phonic-highball-acoustic-guitar/l84967",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Deco-Phonic-Highball-Acoustic-Guitar-Satin-Tobacco-Sunburst/L84967000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,200.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2200.0",
+            "salePrice": "2200.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/beard-guitars-deco-phonic-highball-acoustic-guitar/l84967"
+            }
+        },
+        {
+
+            "name": "Breedlove Oregon Limited Myrtlewood-Myrtlewood Concert CE Acoustic-Electric Guitar",
+            "productID": "site1prodL83509",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/breedlove-oregon-limited-myrtlewood-myrtlewood-concert-ce-acoustic-electric-guitar/l83509000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/breedlove-oregon-limited-myrtlewood-myrtlewood-concert-ce-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Oregon-Limited-Myrtlewood-Myrtlewood-Concert-CE-Acoustic-Electric-Guitar-Canyon/L83509000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,599.00",
+
+            "savings": "$866.00 (25%)",
+
+            "maxSavingsMSRP": "$3,465.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2599.0",
+            "salePrice": "2599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$55&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/breedlove-oregon-limited-myrtlewood-myrtlewood-concert-ce-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 326ce Urban Ash Grand Symphony Acoustic-Electric Guitar",
+            "productID": "site1prodL78491",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-326ce-urban-ash-grand-symphony-acoustic-electric-guitar/l78491000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-326ce-urban-ash-grand-symphony-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/326ce-Urban-Ash-Grand-Symphony-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L78491000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,499.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2499.0",
+            "salePrice": "2499.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$53&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-326ce-urban-ash-grand-symphony-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor GTe Urban Ash Grand Theater Acoustic-Electric Guitar",
+            "productID": "site1prodL77601",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-gte-urban-ash-grand-theater-acoustic-electric-guitar/l77601000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-gte-urban-ash-grand-theater-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/GTe-Urban-Ash-Grand-Theater-Acoustic-Electric-Guitar-Natural/L77601000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "4",
+            "price": "$1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-gte-urban-ash-grand-theater-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor AD17e American Dream Grand Pacific Acoustic-Electric Guitar",
+            "productID": "site1prodL77454",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-ad17e-american-dream-grand-pacific-acoustic-electric-guitar/l77454000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-ad17e-american-dream-grand-pacific-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/AD17e-American-Dream-Grand-Pacific-Acoustic-Electric-Guitar-Black/L77454000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "Starting&nbsp;at $1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/taylor-ad17e-american-dream-grand-pacific-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor AD27e American Dream Grand Pacific Acoustic-Electric Guitar",
+            "productID": "site1prodL77452",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-ad27e-american-dream-grand-pacific-acoustic-electric-guitar/l77452000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-ad27e-american-dream-grand-pacific-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/AD27e-American-Dream-Grand-Pacific-Acoustic-Electric-Guitar-Natural/L77452000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-ad27e-american-dream-grand-pacific-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson J-185 EC Modern Rosewood Acoustic-Electric Guitar",
+            "productID": "site1prodL76867",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-j-185-ec-modern-rosewood-acoustic-electric-guitar/l76867000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-j-185-ec-modern-rosewood-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/J-185-EC-Modern-Rosewood-Acoustic-Electric-Guitar-Rosewood-Burst/L76867000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,949.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2949.0",
+            "salePrice": "2949.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$62&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-j-185-ec-modern-rosewood-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson J-185 EC Modern Walnut Acoustic-Electric Guitar",
+            "productID": "site1prodL76866",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-j-185-ec-modern-walnut-acoustic-electric-guitar/l76866000002000",
+
+            "openBoxUrl": "/guitars/open-box-gibson-j-185-ec-modern-walnut-acoustic-electric-guitar",
+
+            "path": "/guitars/gibson-j-185-ec-modern-walnut-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/J-185-EC-Modern-Walnut-Acoustic-Electric-Guitar-Walnut-Burst/L76866000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,549.00",
+
+            "savings": "$250.00 (9%)",
+
+            "maxSavingsMSRP": "$2,799.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2549.0",
+            "salePrice": "2549.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$54&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-j-185-ec-modern-walnut-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson L-00 Studio Walnut Acoustic-Electric Guitar",
+            "productID": "site1prodL76027",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-l-00-studio-walnut-acoustic-electric-guitar/l76027000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-l-00-studio-walnut-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/L-00-Studio-Walnut-Acoustic-Electric-Guitar-Antique-Natural/L76027000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$1,849.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1849.0",
+            "salePrice": "1849.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$39&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-l-00-studio-walnut-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Epiphone USA Texan Acoustic-Electric Guitar",
+            "productID": "site1prodL74825",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/epiphone-usa-texan-acoustic-electric-guitar/l74825000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/epiphone-usa-texan-hollowbody-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/USA-Texan-Acoustic-Electric-Guitar-Vintage-Sunburst/L74825000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/epiphone-usa-texan-hollowbody-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor Builder's Edition 324ce Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL74664",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-builders-edition-324ce-grand-auditorium-acoustic-electric-guitar/l74664000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-builders-edition-324ce-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Builders-Edition-324ce-Grand-Auditorium-Acoustic-Electric-Guitar-Tobacco-Kona-Burst/L74664000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-builders-edition-324ce-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 224ce-K DLX Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL73858",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-224ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l73858000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-224ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l73858",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/224ce-K-DLX-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L73858000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.0",
+            "salePrice": "1799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-224ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l73858"
+            }
+        },
+        {
+
+            "name": "Taylor 214ce-K DLX Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL73574",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-214ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l73574000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-214ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l73574",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/214ce-K-DLX-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L73574000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-214ce-k-dlx-grand-auditorium-acoustic-electric-guitar/l73574"
+            }
+        },
+        {
+
+            "name": "Gibson L-00 Studio Rosewood Acoustic-Electric Guitar",
+            "productID": "site1prodL73550",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-l-00-studio-rosewood-acoustic-electric-guitar/l73550000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-l-00-studio-rosewood-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/L-00-Studio-Rosewood-Acoustic-Electric-Guitar-Antique-Natural/L73550000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,249.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2249.0",
+            "salePrice": "2249.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$47&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-l-00-studio-rosewood-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson '50s J-45 Original Acoustic-Electric Guitar",
+            "productID": "site1prodL73524",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-50s-j-45-original-acoustic-electric-guitar/l73524000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-50s-j-45-original-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/50s-J-45-Original-Acoustic-Electric-Guitar-Vintage-Sunburst/L73524000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/gibson-50s-j-45-original-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Acoustasonic Telecaster Left-Handed Acoustic-Electric Guitar",
+            "productID": "site1prodL73308",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-acoustasonic-telecaster-left-handed-acoustic-electric-guitar/l73308000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-acoustasonic-telecaster-left-handed-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Acoustasonic-Telecaster-Left-Handed-Acoustic-Electric-Guitar-Natural/L73308000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$1,999.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-acoustasonic-telecaster-left-handed-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 327e Grand Pacific Dreadnought Acoustic-Electric Guitar",
+            "productID": "site1prodL71781",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-327e-grand-pacific-dreadnought-acoustic-electric-guitar/l71781000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-327e-grand-pacific-dreadnought-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/327e-Grand-Pacific-Dreadnought-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L71781000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,299.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-327e-grand-pacific-dreadnought-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 712e V-Class 12-Fret Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL70203",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-712e-v-class-12-fret-grand-concert-acoustic-electric-guitar/l70203000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-712e-v-class-12-fret-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/712e-V-Class-12-Fret-Grand-Concert-Acoustic-Electric-Guitar-Natural/L70203000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "1",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-712e-v-class-12-fret-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 552ce V-Class 12-Fret Grand Concert 12-String Acoustic Electric Guitar",
+            "productID": "site1prodL68986",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-552ce-v-class-12-fret-grand-concert-12-string-acoustic-electric-guitar/l68986000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-552ce-v-class-12-fret-grand-concert-12-string-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/552ce-V-Class-12-Fret-Grand-Concert-12-String-Acoustic-Electric-Guitar-Natural/L68986000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "regularPrice": "$2,899.00",
+
+            "savings": "$100.02 (3%)",
+
+            "maxSavingsMSRP": "$2,899.02",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Price Drop",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2899.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-552ce-v-class-12-fret-grand-concert-12-string-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 412ce-R V-Class Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL68874",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-412ce-r-v-class-grand-concert-acoustic-electric-guitar/l68874000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-412ce-r-v-class-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/412ce-R-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Natural/L68874000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-412ce-r-v-class-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 412ce 12-Fret Special Edition Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL68872",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-412ce-12-fret-special-edition-grand-concert-acoustic-electric-guitar/l68872000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-412ce-12-fret-special-edition-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/412ce-12-Fret-Special-Edition-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L68872000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-412ce-12-fret-special-edition-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 362ce V-Class 12-Fret Grand Concert 12-String Acoustic-Electric Guitar",
+            "productID": "site1prodL68669",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-362ce-v-class-12-fret-grand-concert-12-string-acoustic-electric-guitar/l68669000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-362ce-v-class-12-fret-grand-concert-12-string-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/362ce-V-Class-12-Fret-Grand-Concert-12-String-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L68669000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,299.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-362ce-v-class-12-fret-grand-concert-12-string-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 562ce V-Class Grand Concert 12 Fret 12-String Acoustic-Electric Guitar",
+            "productID": "site1prodL68666",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-562ce-v-class-grand-concert-12-fret-12-string-acoustic-electric-guitar/l68666000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-562ce-v-class-grand-concert-12-fret-12-string-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/562ce-V-Class-Grand-Concert-12-Fret-12-String-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L68666000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-562ce-v-class-grand-concert-12-fret-12-string-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Godin Multiac Steel Natural HG Acoustic-Electric Guitar",
+            "productID": "site1prodL54796",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/godin-multiac-steel-natural-hg-acoustic-electric-guitar/l54796000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/godin-multiac-steel-natural-hg-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Steel-Natural-HG-Acoustic-Electric-Guitar-Natural/L54796000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,149.00",
+
+            "savings": "$601.00 (22%)",
+
+            "maxSavingsMSRP": "$2,750.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2149.0",
+            "salePrice": "2149.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/godin-multiac-steel-natural-hg-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Seagull Artist Limited Tuxedo Black EQ Acoustic-Electric Guitar",
+            "productID": "site1prodL55742",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/seagull-artist-limited-tuxedo-black-eq-acoustic-electric-guitar/l55742000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/seagull-artist-limited-tuxedo-black-eq-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Artist-Limited-Tuxedo-Black-EQ-Acoustic-Electric-Guitar-Tuxedo-Black/L55742000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,599.00",
+
+            "savings": "$436.00 (21%)",
+
+            "maxSavingsMSRP": "$2,035.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/seagull-artist-limited-tuxedo-black-eq-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Guild F-40 Traditional Jumbo Acoustic Guitar",
+            "productID": "site1prodL48702",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/guild-f-40-traditional-jumbo-acoustic-guitar/l48702000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/guild-f-40-traditional-jumbo-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/F-40-Traditional-Jumbo-Acoustic-Guitar-Natural/L48702000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,599.00",
+
+            "savings": "$651.00 (20%)",
+
+            "maxSavingsMSRP": "$3,250.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2599.0",
+            "salePrice": "2599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$55&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/guild-f-40-traditional-jumbo-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Guild F-40 Traditional Jumbo Acoustic Guitar",
+            "productID": "site1prodL48706",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/guild-f-40-traditional-jumbo-acoustic-electric-guitar/l48706000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/guild-f-40-traditional-jumbo-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/F-40-Traditional-Jumbo-Acoustic-Guitar-Antique-Sunburst/L48706000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,699.00",
+
+            "savings": "$676.00 (20%)",
+
+            "maxSavingsMSRP": "$3,375.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2699.0",
+            "salePrice": "2699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$57&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/guild-f-40-traditional-jumbo-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 512ce Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL48700",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-512ce-grand-concert-acoustic-electric-guitar/l48700000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-512ce-grand-concert-acoustic-electric-guitar/l48700",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/512ce-Grand-Concert-Acoustic-Electric-Guitar-Natural/L48700000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-512ce-grand-concert-acoustic-electric-guitar/l48700"
+            }
+        },
+        {
+
+            "name": "Taylor 322ce 12-Fret V-Class Grand Concert Left-Handed Acoustic-Electric Guitar",
+            "productID": "site1prodL48623",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-322ce-12-fret-v-class-grand-concert-left-handed-acoustic-electric-guitar/l48623000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-322ce-12-fret-v-class-grand-concert-left-handed-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/322ce-12-Fret-V-Class-Grand-Concert-Left-Handed-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48623000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,199.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2199.0",
+            "salePrice": "2199.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-322ce-12-fret-v-class-grand-concert-left-handed-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 522e 12-Fret V-Class Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL48625",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-522e-12-fret-v-class-grand-concert-acoustic-electric-guitar/l48625000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-522e-12-fret-v-class-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/522e-12-Fret-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48625000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-522e-12-fret-v-class-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 322e 12-Fret V-Class Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL48519",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-322e-12-fret-v-class-grand-concert-acoustic-electric-guitar/l48519000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-322e-12-fret-v-class-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/322e-12-Fret-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48519000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,299.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-322e-12-fret-v-class-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor Builder's Edition 717 Grand Pacific Dreadnought Acoustic Guitar",
+            "productID": "site1prodL48528",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-builders-edition-717-grand-pacific-dreadnought-acoustic-guitar/l48528000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-builders-edition-717-grand-pacific-dreadnought-acoustic-guitar/l48528000002000",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Builders-Edition-717-Grand-Pacific-Dreadnought-Acoustic-Guitar-Natural/L48528000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/taylor-builders-edition-717-grand-pacific-dreadnought-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 322ce 12-Fret V-Class Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL48184",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-322ce-12-fret-v-class-grand-concert-acoustic-electric-guitar/l48184000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-322ce-12-fret-v-class-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/322ce-12-Fret-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48184000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$2,299.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-322ce-12-fret-v-class-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 324e V-Class Grand Auditorium Left-Handed Acoustic-Electric Guitar",
+            "productID": "site1prodL48188",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-324e-v-class-grand-auditorium-left-handed-acoustic-electric-guitar/l48188000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-324e-v-class-grand-auditorium-left-handed-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/324e-V-Class-Grand-Auditorium-Left-Handed-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48188000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,299.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-324e-v-class-grand-auditorium-left-handed-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 322ce V-Class Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL47658",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-322ce-v-class-grand-concert-acoustic-electric-guitar/l47658000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-322ce-v-class-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/322ce-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L47658000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "3",
+            "price": "$2,299.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-322ce-v-class-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 322e V-Class Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL47659",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-322e-v-class-grand-concert-acoustic-electric-guitar/l47659000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-322e-v-class-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/322e-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L47659000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,299.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-322e-v-class-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 324e V-Class Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL47629",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-324e-v-class-grand-auditorium-acoustic-electric-guitar/l47629000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-324e-v-class-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/324e-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L47629000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,299.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-324e-v-class-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor Builder's Edition 517e Grand Pacific Dreadnought Acoustic-Electric Guitar",
+            "productID": "site1prodL47628",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-builders-edition-517e-grand-pacific-dreadnought-acoustic-electric-guitar/l47628000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-builders-edition-517e-grand-pacific-dreadnought-acoustic-electric-guitar/l47628000001000",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Builders-Edition-517e-Grand-Pacific-Dreadnought-Acoustic-Electric-Guitar-Natural/L47628000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/taylor-builders-edition-517e-grand-pacific-dreadnought-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 224ce-K DLX Special Edition Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL43764",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-224ce-k-dlx-special-edition-grand-auditorium-acoustic-electric-guitar/l43764000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-224ce-k-dlx-special-edition-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/224ce-K-DLX-Special-Edition-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L43764000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "3",
+            "price": "$1,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.0",
+            "salePrice": "1799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-224ce-k-dlx-special-edition-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 324ce-LH V-Class Grand Auditorium Left-Handed Acoustic-Electric Guitar",
+            "productID": "site1prodL36064",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-324ce-lh-v-class-grand-auditorium-left-handed-acoustic-electric-guitar/l36064000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/open-box-taylor-324ce-lh-v-class-grand-auditorium-left-handed-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/324ce-LH-V-Class-Grand-Auditorium-Left-Handed-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L36064000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,199.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2199.0",
+            "salePrice": "2199.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/open-box-taylor-324ce-lh-v-class-grand-auditorium-left-handed-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 414ce V-Class Special Edition Grand Auditorium Left-Handed Acoustic-Electric Guitar",
+            "productID": "site1prodL35971",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-left-handed-acoustic-electric-guitar/l35971000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-left-handed-acoustic-electric-guitar/l35971",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-V-Class-Special-Edition-Grand-Auditorium-Left-Handed-Acoustic-Electric-Guitar-Natural/L35971000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-left-handed-acoustic-electric-guitar/l35971"
+            }
+        },
+        {
+
+            "name": "Taylor 414ce V-Class Special Edition Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL30144",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-acoustic-electric-guitar/l30144000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-acoustic-electric-guitar/l30144",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-V-Class-Special-Edition-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L30144000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-414ce-v-class-special-edition-grand-auditorium-acoustic-electric-guitar/l30144"
+            }
+        },
+        {
+
+            "name": "Gibson L-00 Standard Acoustic-Electric Guitar",
+            "productID": "site1prodL28992",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-l-00-standard-acoustic-electric-guitar/l28992000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-l-00-standard-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/L-00-Standard-Acoustic-Electric-Guitar-Vintage-Sunburst/L28992000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-l-00-standard-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 514ce Lutz V-Class Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL27750",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-514ce-lutz-v-class-grand-auditorium-acoustic-electric-guitar/l27750000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-514ce-lutz-v-class-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/514ce-Lutz-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L27750000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,899.00",
+
+            "savings": "$1.01 (0%)",
+
+            "maxSavingsMSRP": "$2,900.01",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2899.0",
+            "salePrice": "2899.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$61&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-514ce-lutz-v-class-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 414ce-R V-Class Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL26407",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-414ce-r-v-class-grand-auditorium-acoustic-electric-guitar/l26407000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-414ce-r-v-class-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-R-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L26407000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "3",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-414ce-r-v-class-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 514ce V-Class Grand Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL20784",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-514ce-v-class-grand-auditorium-acoustic-electric-guitar/l20784000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-514ce-v-class-grand-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/514ce-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L20784000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-514ce-v-class-grand-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Takamine EF360SC-TT Thermal Top Acoustic-Electric Guitar",
+            "productID": "site1prodK46236",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/takamine-ef360sc-tt-thermal-top-acoustic-electric-guitar/k46236000001000",
+
+            "openBoxUrl": "/guitars/open-box-takamine-ef360sc-tt-thermal-top-acoustic-electric-guitar",
+
+            "path": "/guitars/takamine-ef360sc-tt-thermal-top-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/EF360SC-TT-Thermal-Top-Acoustic-Electric-Guitar-Gloss-Natural/K46236000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,849.99",
+
+            "savings": "$830.00 (31%)",
+
+            "maxSavingsMSRP": "$2,679.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1849.99",
+            "salePrice": "1849.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$39&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/takamine-ef360sc-tt-thermal-top-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Breedlove Oregon Concert CE Sitka Spruce - Myrtlewood Acoustic-Electric Guitar",
+            "productID": "site1prodJ48814",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/breedlove-oregon-concert-ce-sitka-spruce--myrtlewood-acoustic-electric-guitar/j48814000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/breedlove-oregon-concert-ce-sitka-spruce--myrtlewood-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Oregon-Concert-CE-Sitka-Spruce--Myrtlewood-Acoustic-Electric-Guitar-Gloss-Natural/J48814000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,399.00",
+
+            "savings": "$799.67 (25%)",
+
+            "maxSavingsMSRP": "$3,198.67",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2399.0",
+            "salePrice": "2399.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$50&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/breedlove-oregon-concert-ce-sitka-spruce--myrtlewood-acoustic-electric-guitar"
+            }
+        }
+    ],
+    "omnitureReportingData": {
+
+        "paginationNumber": "page 1",
+        "displayPerPage": "90",
+        "listFilters": "condition:new|category:acoustic guitars|price:1500 - 2000",
+        "sortByType": "best selling"
+    }
+}

--- a/backend/seed/classical.raw.json
+++ b/backend/seed/classical.raw.json
@@ -1,0 +1,2915 @@
+{
+
+    "params": [{
+        "param": "Ns",
+        "value": "bS"
+    }, {
+        "param": "Nao",
+        "value": "0"
+    }, {
+        "param": "pageName",
+        "value": "category-page"
+    }, {
+        "param": "N",
+        "value": "100902 100511 100512 100902 500024 100511 100512"
+    }, {
+        "param": "recsPerPage",
+        "value": "90"
+    }],
+    "hasMoreBrandFacets": false,
+
+    "pagination": [{
+        "results": "1-35",
+        "display": "90",
+        "totalResults": "35",
+        "view": "",
+        "totalCompared": "0",
+        "currentPage": "1",
+        "pages": [
+
+            {
+                "page": "1",
+                "active": false
+            }
+        ]
+    }],
+
+    "sortBy": [{
+            "value": "bM",
+            "name": "Best Match"
+        },
+        {
+            "value": "bS",
+            "name": "Best Sellers",
+            "selected": true
+        },
+
+        {
+            "value": "r",
+            "name": "Relevance"
+        },
+
+        {
+            "value": "oR",
+            "name": "Customer Ratings"
+        },
+
+        {
+            "value": "pHL",
+            "name": "Price - High to Low"
+        },
+        {
+            "value": "pLH",
+            "name": "Price - Low to High"
+        },
+        {
+            "value": "cD",
+            "name": "Newest First"
+        },
+        {
+            "value": "bN",
+            "name": "Brand Name A-Z"
+        }
+    ],
+    "facets": [{
+
+        "facetName": "Category",
+        "facetId": "500000",
+
+        "dimensionName": "category",
+
+        "state": "open",
+        "clearURL": "/category-page?N=100902+100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "hidden",
+
+        "selected": true,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Classical &amp; Nylon Guitars",
+                "facetValue": "500024",
+                "itemCount": "",
+                "seoURL": "/category-page?N=100902+100511+100512",
+
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Brands",
+        "facetId": "200000",
+
+        "dimensionName": "brand",
+
+        "state": "open",
+        "clearURL": "/classical-nylon-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Alvarez",
+                "facetValue": "200076",
+                "itemCount": "2",
+                "seoURL": "/classical-nylon-guitars/alvarez--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Cordoba",
+                "facetValue": "200439",
+                "itemCount": "9",
+                "seoURL": "/classical-nylon-guitars/cordoba--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Godin",
+                "facetValue": "200855",
+                "itemCount": "5",
+                "seoURL": "/classical-nylon-guitars/godin--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Kremona",
+                "facetValue": "201159",
+                "itemCount": "4",
+                "seoURL": "/classical-nylon-guitars/kremona--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Martin",
+                "facetValue": "202620",
+                "itemCount": "2",
+                "seoURL": "/classical-nylon-guitars/martin--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Ortega",
+                "facetValue": "3013410",
+                "itemCount": "3",
+                "seoURL": "/classical-nylon-guitars/ortega--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Takamine",
+                "facetValue": "202079",
+                "itemCount": "3",
+                "seoURL": "/classical-nylon-guitars/takamine--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Taylor",
+                "facetValue": "202088",
+                "itemCount": "4",
+                "seoURL": "/classical-nylon-guitars/taylor--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Yamaha",
+                "facetValue": "202601",
+                "itemCount": "3",
+                "seoURL": "/classical-nylon-guitars/yamaha--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Condition",
+        "facetId": "100901",
+
+        "dimensionName": "seeablecondition",
+
+        "state": "open",
+        "clearURL": "/classical-nylon-guitars?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": true,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "New",
+                "facetValue": "100902",
+                "itemCount": "",
+                "seoURL": "/classical-nylon-guitars?N=100511+100512",
+
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Price",
+        "facetId": "100501",
+
+        "dimensionName": "price",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "",
+
+        "selected": true,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "$1,500 - $2,000&nbsp;",
+                "facetValue": "100511",
+                "itemCount": "",
+                "seoURL": "",
+                "disabled": false,
+                "selected": true
+            },
+            {
+                "displayValue": "$2,000 - $3,000&nbsp;",
+                "facetValue": "100512",
+                "itemCount": "",
+                "seoURL": "",
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Customer Rating",
+        "facetId": "100401",
+
+        "dimensionName": "customerrating",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "<span class='stars small rate-10'></span>5 only",
+                "facetValue": "100402",
+                "itemCount": "15",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-8'></span>4 & up",
+                "facetValue": "100403",
+                "itemCount": "21",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-6'></span>3 & up",
+                "facetValue": "100404",
+                "itemCount": "22",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-4'></span>2 & up",
+                "facetValue": "100405",
+                "itemCount": "22",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-2'></span>1 & up",
+                "facetValue": "100406",
+                "itemCount": "22",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Body Type",
+        "facetId": "426100",
+
+        "dimensionName": "acoustic_body_type",
+
+        "state": "open",
+        "clearURL": "/classical-nylon-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Auditorium",
+                "facetValue": "4294963159",
+                "itemCount": "2",
+                "seoURL": "/classical-nylon-guitars/new--auditorium?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Classical",
+                "facetValue": "3015009",
+                "itemCount": "16",
+                "seoURL": "/classical-nylon-guitars/new--classical?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Flamenco/Thin Body",
+                "facetValue": "3015004",
+                "itemCount": "3",
+                "seoURL": "/classical-nylon-guitars/new--flamenco-thin-body?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Grand Auditorium",
+                "facetValue": "4294963154",
+                "itemCount": "1",
+                "seoURL": "/classical-nylon-guitars/new--grand-auditorium?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Grand Concert",
+                "facetValue": "4294963150",
+                "itemCount": "4",
+                "seoURL": "/classical-nylon-guitars/new--grand-concert?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mini Jumbo",
+                "facetValue": "4294963141",
+                "itemCount": "1",
+                "seoURL": "/classical-nylon-guitars/new--mini-jumbo?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Performance Level",
+        "facetId": "407300",
+
+        "dimensionName": "performance_level",
+
+        "state": "open",
+        "clearURL": "/classical-nylon-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Professional",
+                "facetValue": "4294966659",
+                "itemCount": "24",
+                "seoURL": "/classical-nylon-guitars/new--professional?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Acoustic-Electric",
+        "facetId": "425600",
+
+        "dimensionName": "acoustic-electric",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Yes",
+                "facetValue": "4294963170",
+                "itemCount": "16",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "No",
+                "facetValue": "4294963169",
+                "itemCount": "19",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Color",
+        "facetId": "402500",
+
+        "dimensionName": "color",
+
+        "state": "open",
+        "clearURL": "/classical-nylon-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Natural",
+                "facetValue": "4294966891",
+                "itemCount": "27",
+                "seoURL": "/classical-nylon-guitars/new--natural?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Model",
+        "facetId": "3016952",
+
+        "dimensionName": "model",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "312",
+                "facetValue": "3018815",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "412",
+                "facetValue": "3019236",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "414",
+                "facetValue": "3019204",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Number of Strings",
+        "facetId": "406800",
+
+        "dimensionName": "number_of_strings",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "6 String",
+                "facetValue": "4294966899",
+                "itemCount": "31",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "7 String",
+                "facetValue": "4294966585",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Left- or Right-Handed",
+        "facetId": "407000",
+
+        "dimensionName": "orientation",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Left Handed",
+                "facetValue": "4294966611",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Right Handed",
+                "facetValue": "4294966905",
+                "itemCount": "29",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Country of Origin",
+        "facetId": "402700",
+
+        "dimensionName": "country_of_origin",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Bulgaria",
+                "facetValue": "4294965503",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Canada",
+                "facetValue": "4294966526",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "China",
+                "facetValue": "4294966892",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Japan",
+                "facetValue": "4294966605",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Spain",
+                "facetValue": "4294966590",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "United States",
+                "facetValue": "4294966675",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Guitar Size",
+        "facetId": "421500",
+
+        "dimensionName": "guitar_size",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "4/4",
+                "facetValue": "4294966598",
+                "itemCount": "24",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Top Material",
+        "facetId": "3012157",
+
+        "dimensionName": "top_material",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Bamboo",
+                "facetValue": "3012169",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Cedar",
+                "facetValue": "3012168",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mahogany",
+                "facetValue": "3012159",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Spruce",
+                "facetValue": "3012166",
+                "itemCount": "14",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Back & Side Material",
+        "facetId": "3012142",
+
+        "dimensionName": "back___side_material",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Acacia",
+                "facetValue": "3012145",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Cherry",
+                "facetValue": "3012148",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mahogany",
+                "facetValue": "3012151",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Maple",
+                "facetValue": "3012154",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Rosewood",
+                "facetValue": "3012152",
+                "itemCount": "10",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Sapele",
+                "facetValue": "3012149",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Walnut",
+                "facetValue": "3012150",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Fingerboard Material",
+        "facetId": "3012709",
+
+        "dimensionName": "fingerboard_material",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Ebony",
+                "facetValue": "3012711",
+                "itemCount": "24",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Rosewood",
+                "facetValue": "3012714",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Composite Material",
+                "facetValue": "3015131",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Accessories Included",
+        "facetId": "3016071",
+
+        "dimensionName": "accessories_included",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Gig bag",
+                "facetValue": "3016077",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Hardshell case",
+                "facetValue": "3016072",
+                "itemCount": "14",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Number of Frets",
+        "facetId": "3016006",
+
+        "dimensionName": "number_of_frets",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "17",
+                "facetValue": "3016007",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "18",
+                "facetValue": "3016008",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "19",
+                "facetValue": "3016016",
+                "itemCount": "16",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "20",
+                "facetValue": "3016010",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "20",
+                "facetValue": "3021749",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "21",
+                "facetValue": "3016017",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "22",
+                "facetValue": "3016020",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "24",
+                "facetValue": "3016015",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Nut Width",
+        "facetId": "3016021",
+
+        "dimensionName": "nut_width",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "1.87 in. (47.49 mm)",
+                "facetValue": "3016028",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.875 in. (47.62 mm)",
+                "facetValue": "3016032",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.89 in. (48 mm)",
+                "facetValue": "3016027",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.97 in. (50 mm)",
+                "facetValue": "3016039",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "2 in. (52 mm)",
+                "facetValue": "3016034",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "2 in. (52mm)",
+                "facetValue": "3016062",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "2.16 in. (55 mm)",
+                "facetValue": "3016029",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Series",
+        "facetId": "3017404",
+
+        "dimensionName": "series_new",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "300 Series",
+                "facetValue": "3017497",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "400 Series",
+                "facetValue": "3017503",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "String Type",
+        "facetId": "3017647",
+
+        "dimensionName": "string_type",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Nylon",
+                "facetValue": "3017650",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Savings & Specials",
+        "facetId": "100201",
+
+        "dimensionName": "deals",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Best Sellers",
+                "facetValue": "100206",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "New Arrivals",
+        "facetId": "100301",
+
+        "dimensionName": "newarrivals",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "New",
+                "facetValue": "100302",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Pre-Order",
+                "facetValue": "100303",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Financing",
+        "facetId": "3000000",
+
+        "dimensionName": "financing",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "48 Month Financing",
+                "facetValue": "3014271",
+                "itemCount": "27",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "In Stock",
+        "facetId": "3000002",
+
+        "dimensionName": "in stock",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Now In Stock",
+                "facetValue": "3024872",
+                "itemCount": "18",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }],
+    "categories": [
+
+        {
+            "displayName": "New Acoustic Classical & Nylon Guitars",
+            "catId": "site1ALA",
+            "dimVal": "500025",
+            "url": "/acoustic-classical-nylon-guitars/new?N=100511+100512",
+            "count": "33"
+        },
+        {
+            "displayName": "New Flamenco Guitars",
+            "catId": "site1ALC",
+            "dimVal": "511952",
+            "url": "/flamenco-guitars/new?N=100511+100512",
+            "count": "2"
+        }
+    ],
+    "products": [
+
+        {
+
+            "name": "Godin Multiac Grand Concert SA Nylon String Electric Guitar",
+            "productID": "site1prod511911",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/godin-multiac-grand-concert-sa-nylon-string-electric-guitar/511911000180000",
+
+            "openBoxUrl": "/guitars/open-box-godin-multiac-grand-concert-sa-nylon-string-electric-guitar",
+
+            "path": "/guitars/godin-multiac-grand-concert-sa-nylon-string-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Grand-Concert-SA-Nylon-String-Electric-Guitar-High-Gloss-Natural/511911000180000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "A nylon-string electric with the feel of a classical.",
+            "rating": "10",
+            "reviews": "10",
+            "price": "$1,950.00",
+
+            "savings": "$250.00 (11%)",
+
+            "maxSavingsMSRP": "$2,200.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1950.0",
+            "salePrice": "1950.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/godin-multiac-grand-concert-sa-nylon-string-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba C12 CD Classical Guitar",
+            "productID": "site1prodH96255",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-c12-cd-classical-guitar/h96255000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-c12-cd-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/C12-CD-Classical-Guitar-Natural/H96255000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "8",
+            "price": "$2,049.00",
+
+            "savings": "$791.00 (28%)",
+
+            "maxSavingsMSRP": "$2,840.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2049.0",
+            "salePrice": "2049.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$43&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-c12-cd-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Godin Multiac Nylon String SA Electric Guitar",
+            "productID": "site1prod511886",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/godin-multiac-nylon-string-sa-electric-guitar/511886000180000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/godin-multiac-nylon-string-sa-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Nylon-String-SA-Electric-Guitar-High-Gloss-Natural/511886000180000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "The perfect way to incorporate lush nylon sound into your music!",
+            "rating": "10",
+            "reviews": "12",
+            "price": "$1,950.00",
+
+            "savings": "$250.00 (11%)",
+
+            "maxSavingsMSRP": "$2,200.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1950.0",
+            "salePrice": "1950.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/godin-multiac-nylon-string-sa-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Kremona Solea Classical Guitar",
+            "productID": "site1prodH72435",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/kremona-solea-classical-guitar/h72435000001000",
+
+            "openBoxUrl": "/guitars/open-box-kremona-solea-classical-guitar",
+
+            "path": "/guitars/kremona-solea-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Solea-Classical-Guitar-Natural/H72435000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "Solid cedar top, solid cocobolo back &amp; sides, and an ebony fingerboard.",
+            "rating": "9",
+            "reviews": "7",
+            "price": "$1,899.00",
+
+            "savings": "$500.00 (21%)",
+
+            "maxSavingsMSRP": "$2,399.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "15% off w/ guitarfest",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1899.0",
+            "salePrice": "1899.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$40&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/kremona-solea-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba GK Pro Negra Acoustic-Electric Guitar",
+            "productID": "site1prodJ07421",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-gk-pro-negra-acoustic-electric-guitar/j07421000000000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-gk-pro-negra-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/GK-Pro-Negra-Acoustic-Electric-Guitar/J07421000000000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "7",
+            "price": "$1,899.00",
+
+            "savings": "$736.00 (28%)",
+
+            "maxSavingsMSRP": "$2,635.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1899.0",
+            "salePrice": "1899.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$40&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-gk-pro-negra-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Kremona 90th Anniversary Nylon-String Guitar",
+            "productID": "site1prodJ12687",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/kremona-90th-anniversary-nylon-string-guitar/j12687000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/kremona-90th-anniversary-nylon-string-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/90th-Anniversary-Nylon-String-Guitar-Natural/J12687000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "7",
+            "price": "$2,199.00",
+
+            "savings": "$390.00 (15%)",
+
+            "maxSavingsMSRP": "$2,589.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "15% off w/ guitarfest",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2199.0",
+            "salePrice": "2199.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/kremona-90th-anniversary-nylon-string-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba C12 SP Classical Guitar",
+            "productID": "site1prodH96236",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-c12-sp-classical-guitar/h96236000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-c12-sp-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/C12-SP-Classical-Guitar-Natural/H96236000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "6",
+            "price": "$2,049.00",
+
+            "savings": "$791.00 (28%)",
+
+            "maxSavingsMSRP": "$2,840.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2049.0",
+            "salePrice": "2049.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$43&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-c12-sp-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Kremona Rosa Blanca Flamenco Guitar",
+            "productID": "site1prodH82485",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/kremona-rosa-blanca-flamenco-guitar/h82485000001000",
+
+            "openBoxUrl": "/guitars/open-box-kremona-rosa-blanca-flamenco-guitar",
+
+            "path": "/guitars/kremona-rosa-blanca-flamenco-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Rosa-Blanca-Flamenco-Guitar-Gloss-Natural/H82485000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "5",
+            "price": "$1,799.00",
+
+            "savings": "$450.00 (20%)",
+
+            "maxSavingsMSRP": "$2,249.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "15% off w/ guitarfest",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.0",
+            "salePrice": "1799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/kremona-rosa-blanca-flamenco-guitar"
+            }
+        },
+        {
+
+            "name": "Godin Multiac Nylon Duet Ambiance Acoustic-Electric Guitar",
+            "productID": "site1prod430653",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/godin-multiac-nylon-duet-ambiance-acoustic-electric-guitar/430653000010000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/godin-multiac-nylon-duet-ambiance-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Nylon-Duet-Ambiance-Acoustic-Electric-Guitar-Natural/430653000010000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "The Multiac Nylon Duet Ambiance features a 25-1/2 in. scale and slimmer nut width than the classically...",
+            "rating": "9",
+            "reviews": "5",
+            "price": "$1,749.00",
+
+            "savings": "$146.00 (8%)",
+
+            "maxSavingsMSRP": "$1,895.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1749.0",
+            "salePrice": "1749.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/godin-multiac-nylon-duet-ambiance-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Godin Multiac Grand Concert Duet Ambiance Nylon String Acoustic-Electric Guitar",
+            "productID": "site1prod620258",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/godin-multiac-grand-concert-duet-ambiance-nylon-string-acoustic-electric-guitar/620258000872000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/godin-multiac-grand-concert-duet-ambiance-nylon-string-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Grand-Concert-Duet-Ambiance-Nylon-String-Acoustic-Electric-Guitar-High-Gloss-Natural/620258000872000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "The Multiac Grand Concert Duet Ambiance nylon-string acoustic-electric guitar features state of the art custom...",
+            "rating": "10",
+            "reviews": "5",
+            "price": "$1,695.00",
+
+            "savings": "$230.00 (12%)",
+
+            "maxSavingsMSRP": "$1,925.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1695.0",
+            "salePrice": "1695.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/godin-multiac-grand-concert-duet-ambiance-nylon-string-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor Special Ed 412ce-NR Rosewood Nylon Acoustic -Electric Grand Concert Guitar",
+            "productID": "site1prodL86962",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-special-ed-412ce-nr-rosewood-nylon-acoustic-electric-grand-concert-guitar/l86962000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-special-ed-412ce-nr-rosewood-nylon-acoustic-electric-grand-concert-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Special-Ed-412ce-NR-Rosewood-Nylon-Acoustic-Electric-Grand-Concert-Guitar-Shaded-Edge-Burst/L86962000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,799.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-special-ed-412ce-nr-rosewood-nylon-acoustic-electric-grand-concert-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba Esteso Cedar Luthier Select Acoustic Classical Guitar",
+            "productID": "site1prodL73548",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-esteso-cedar-luthier-select-acoustic-classical-guitar/l73548000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-esteso-cedar-luthier-select-acoustic-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Esteso-Cedar-Luthier-Select-Acoustic-Classical-Guitar-Natural/L73548000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,499.00",
+
+            "savings": "$976.00 (28%)",
+
+            "maxSavingsMSRP": "$3,475.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2499.0",
+            "salePrice": "2499.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$53&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-esteso-cedar-luthier-select-acoustic-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Godin ACS Grand Concert Acoustic-Electric Guitar",
+            "productID": "site1prodL55196",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/godin-acs-grand-concert-acoustic-electric-guitar/l55196000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/godin-acs-grand-concert-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/ACS-Grand-Concert-Acoustic-Electric-Guitar-Black/L55196000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,579.00",
+
+            "savings": "$321.00 (17%)",
+
+            "maxSavingsMSRP": "$1,900.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1579.0",
+            "salePrice": "1579.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/godin-acs-grand-concert-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Ortega Custom Master M4CS All-Solid Classical Guitar",
+            "productID": "site1prodL78918",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/ortega-custom-master-m4cs-all-solid-classical-guitar/l78918000001001",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/ortega-custom-master-m4cs-all-solid-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Custom-Master-M4CS-All-Solid-Classical-Guitar-Gloss-Natural-4-4/L78918000001001-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,699.99",
+
+            "savings": "$580.01 (25%)",
+
+            "maxSavingsMSRP": "$2,280.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.99",
+            "salePrice": "1699.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/ortega-custom-master-m4cs-all-solid-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Ortega Custom Master M5CS All-Solid Classical Guitar",
+            "productID": "site1prodL78916",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/ortega-custom-master-m5cs-all-solid-classical-guitar/l78916000001001",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/ortega-custom-master-m5cs-all-solid-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Custom-Master-M5CS-All-Solid-Classical-Guitar-Gloss-Natural-4-4/L78916000001001-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,599.99",
+
+            "savings": "$560.01 (26%)",
+
+            "maxSavingsMSRP": "$2,160.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.99",
+            "salePrice": "1599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/ortega-custom-master-m5cs-all-solid-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Martin 000C12-16E Left Handed Auditorium Acoustic-Electric Guitar",
+            "productID": "site1prodL77138",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-000c12-16e-left-handed-auditorium-acoustic-electric-guitar/l77138000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-000c12-16e-left-handed-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/000C12-16E-Left-Handed-Auditorium-Acoustic-Electric-Guitar-Natural/L77138000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-000c12-16e-left-handed-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba Esteso SP Spruce Top Luthier Select Acoustic Classical Guitar",
+            "productID": "site1prodL73549",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-esteso-sp-spruce-top-luthier-select-acoustic-classical-guitar/l73549000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-esteso-sp-spruce-top-luthier-select-acoustic-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Esteso-SP-Spruce-Top-Luthier-Select-Acoustic-Classical-Guitar-Natural/L73549000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,649.00",
+
+            "savings": "$1,026.00 (28%)",
+
+            "maxSavingsMSRP": "$3,675.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2649.0",
+            "salePrice": "2649.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$56&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-esteso-sp-spruce-top-luthier-select-acoustic-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 312ce-N Grand Concert Nylon-String Acoustic-Electric Guitar",
+            "productID": "site1prodL28953",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-312ce-n-grand-concert-nylon-string-acoustic-electric-guitar/l28953000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-312ce-n-grand-concert-nylon-string-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/312ce-N-Grand-Concert-Nylon-String-Acoustic-Electric-Guitar-Natural/L28953000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-312ce-n-grand-concert-nylon-string-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba Solista SP Classical Guitar",
+            "productID": "site1prodH96244",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-solista-sp-classical-guitar/h96244000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-solista-sp-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Solista-SP-Classical-Guitar-Natural/H96244000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "3",
+            "price": "$1,749.00",
+
+            "savings": "$681.00 (28%)",
+
+            "maxSavingsMSRP": "$2,430.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1749.0",
+            "salePrice": "1749.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$37&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-solista-sp-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Alvarez CYM75 Yairi Masterworks Classical Acoustic Guitar",
+            "productID": "site1prodJ09276",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/alvarez-cym75-yairi-masterworks-classical-acoustic-guitar/j09276000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/alvarez-cym75-yairi-masterworks-classical-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/CYM75-Yairi-Masterworks-Classical-Acoustic-Guitar-Natural/J09276000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "9",
+            "price": "$1,999.00",
+
+            "savings": "$1,000.00 (33%)",
+
+            "maxSavingsMSRP": "$2,999.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/alvarez-cym75-yairi-masterworks-classical-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Kremona Fiesta CW-7 Classical Electric Guitar",
+            "productID": "site1prodJ05988",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/kremona-fiesta-cw-7-classical-electric-guitar/j05988000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/kremona-fiesta-cw-7-classical-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Fiesta-CW-7-Classical-Electric-Guitar-Gloss-Natural/J05988000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "4",
+            "price": "$1,599.00",
+
+            "savings": "$400.00 (20%)",
+
+            "maxSavingsMSRP": "$1,999.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "15% off w/ guitarfest",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/kremona-fiesta-cw-7-classical-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba FCWE Gipsy Kings Reissue Nylon-String Flamenco Acoustic-Electric Guitar",
+            "productID": "site1prodH98890",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-fcwe-gipsy-kings-reissue-nylon-string-flamenco-acoustic-electric-guitar/h98890000000000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-fcwe-gipsy-kings-reissue-nylon-string-flamenco-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/FCWE-Gipsy-Kings-Reissue-Nylon-String-Flamenco-Acoustic-Electric-Guitar/H98890000000000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$2,199.00",
+
+            "savings": "$851.00 (28%)",
+
+            "maxSavingsMSRP": "$3,050.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2199.0",
+            "salePrice": "2199.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-fcwe-gipsy-kings-reissue-nylon-string-flamenco-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba Solista CD/IN Acoustic Nylon String Classical Guitar",
+            "productID": "site1prod515597",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-solista-cd-in-acoustic-nylon-string-classical-guitar/515597000000000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-solista-cd-in-acoustic-nylon-string-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Solista-CD-IN-Acoustic-Nylon-String-Classical-Guitar/515597000000000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "8",
+            "price": "$1,799.00",
+
+            "savings": "$631.00 (26%)",
+
+            "maxSavingsMSRP": "$2,430.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.0",
+            "salePrice": "1799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-solista-cd-in-acoustic-nylon-string-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Takamine TC132SC Acoustic-Electric Nylon String Guitar",
+            "productID": "site1prod516294",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/takamine-tc132sc-acoustic-electric-nylon-string-guitar/516294000010000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/takamine-tc132sc-acoustic-electric-nylon-string-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/TC132SC-Acoustic-Electric-Nylon-String-Guitar-Natural/516294000010000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "The TC132SC classical cutaway guitar features a solid Cedar top, Rosewood back and sides and the &quot;Cool Tube...",
+            "rating": "10",
+            "reviews": "8",
+            "price": "$1,549.99",
+
+            "savings": "$760.00 (33%)",
+
+            "maxSavingsMSRP": "$2,309.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1549.99",
+            "salePrice": "1549.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$33&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/takamine-tc132sc-acoustic-electric-nylon-string-guitar"
+            }
+        },
+        {
+
+            "name": "Cordoba 55FCE Thinbody Limited Flamenco Acoustic-Electric Guitar",
+            "productID": "site1prodJ08470",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/cordoba-55fce-thinbody-limited-flamenco-acoustic-electric-guitar/j08470000000000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/cordoba-55fce-thinbody-limited-flamenco-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/55FCE-Thinbody-Limited-Flamenco-Acoustic-Electric-Guitar/J08470000000000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "5",
+            "price": "$1,689.00",
+
+            "savings": "$661.00 (28%)",
+
+            "maxSavingsMSRP": "$2,350.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1689.0",
+            "salePrice": "1689.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/cordoba-55fce-thinbody-limited-flamenco-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Martin 000C12-16E Nylon Cutaway Acoustic-Electric Guitar",
+            "productID": "site1prodL73599",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/martin-16-series-nylon-string-000-cutaway-auditorium-acoustic-electric-guitar/l73599000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/martin-16-series-nylon-string-000-cutaway-auditorium-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/000C12-16E-Nylon-Cutaway-Acoustic-Electric-Guitar-Natural/L73599000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,099.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2099.0",
+            "salePrice": "2099.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$44&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/martin-16-series-nylon-string-000-cutaway-auditorium-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Takamine TSP148NC Nylon Thinline Acoustic-Electric Guitar",
+            "productID": "site1prodL59869",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/takamine-tsp148nc-nylon-thinline-acoustic-electric-guitar/l59869000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/takamine-tsp148nc-nylon-thinline-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/TSP148NC-Nylon-Thinline-Acoustic-Electric-Guitar-Satin-Natural/L59869000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "3",
+            "price": "$1,549.99",
+
+            "savings": "$950.00 (38%)",
+
+            "maxSavingsMSRP": "$2,499.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1549.99",
+            "salePrice": "1549.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$33&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/takamine-tsp148nc-nylon-thinline-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 412ce-N Rosewood Grand Concert Nylon String Acoustic-Electric Guitar",
+            "productID": "site1prodL29998",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-412ce-n-rosewood-grand-concert-nylon-string-acoustic-electric-guitar/l29998000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-412ce-n-rosewood-grand-concert-nylon-string-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/412ce-N-Rosewood-Grand-Concert-Nylon-String-Acoustic-Electric-Guitar-Natural/L29998000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "6",
+            "reviews": "1",
+            "price": "$2,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2699.0",
+            "salePrice": "2699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$57&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-412ce-n-rosewood-grand-concert-nylon-string-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Takamine TC135SC Classical 24-Fret Cutaway Acoustic-Electric Guitar",
+            "productID": "site1prod512196",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/takamine-tc135sc-classical-24-fret-cutaway-acoustic-electric-guitar/512196000010000",
+
+            "openBoxUrl": "/guitars/open-box-takamine-tc135sc-classical-24-fret-cutaway-acoustic-electric-guitar",
+
+            "path": "/guitars/takamine-tc135sc-classical-24-fret-cutaway-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/TC135SC-Classical-24-Fret-Cutaway-Acoustic-Electric-Guitar-Natural/512196000010000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$1,899.99",
+
+            "savings": "$872.00 (31%)",
+
+            "maxSavingsMSRP": "$2,771.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1899.99",
+            "salePrice": "1899.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$40&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/takamine-tc135sc-classical-24-fret-cutaway-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Yamaha NCX5 Acoustic-Electric Classical Guitar",
+            "productID": "site1prodL73867",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/yamaha-ncx5-acoustic-electric-classical-guitar/l73867000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/yamaha-ncx5-acoustic-electric-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/NCX5-Acoustic-Electric-Classical-Guitar-Natural/L73867000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,889.99",
+
+            "savings": "$1,281.01 (40%)",
+
+            "maxSavingsMSRP": "$3,171.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1889.99",
+            "salePrice": "1889.99",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/yamaha-ncx5-acoustic-electric-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Yamaha NTX5 Acoustic-Electric Classical Guitar",
+            "productID": "site1prodL73866",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/yamaha-ntx5-acoustic-electric-classical-guitar/l73866000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/yamaha-ntx5-acoustic-electric-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/NTX5-Acoustic-Electric-Classical-Guitar-Natural/L73866000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,889.99",
+
+            "savings": "$1,281.01 (40%)",
+
+            "maxSavingsMSRP": "$3,171.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1889.99",
+            "salePrice": "1889.99",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/yamaha-ntx5-acoustic-electric-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Yamaha GC32 Handcrafted Cedar Classical Guitar",
+            "productID": "site1prodL93201",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/yamaha-gc32-handcrafted-cedar-classical-guitar/l93201000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/yamaha-gc32-handcrafted-cedar-classical-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/GC32-Handcrafted-Cedar-Classical-Guitar-Natural-Spruce/L93201000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,779.99",
+
+            "savings": "$1,256.41 (41%)",
+
+            "maxSavingsMSRP": "$3,036.40",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "New",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1779.99",
+            "salePrice": "1779.99",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/yamaha-gc32-handcrafted-cedar-classical-guitar"
+            }
+        },
+        {
+
+            "name": "Alvarez CY75 Yairi Classical Acoustic Guitar",
+            "productID": "site1prodL83874",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/alvarez-cy75-yairi-classical-acoustic-guitar/l83874000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/alvarez-cy75-yairi-classical-acoustic-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/CY75-Yairi-Classical-Acoustic-Guitar-Natural/L83874000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,529.00",
+
+            "savings": "$570.00 (27%)",
+
+            "maxSavingsMSRP": "$2,099.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1529.0",
+            "salePrice": "1529.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$32&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/alvarez-cy75-yairi-classical-acoustic-guitar"
+            }
+        },
+        {
+
+            "name": "Ortega BWSM/2 Ben Woods Signature Flamenco Acoustic-Electric Guitar",
+            "productID": "site1prodL52103",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/ortega-bwsm-2-ben-woods-signature-flamenco-acoustic-electric-guitar/l52103000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/ortega-bwsm-2-ben-woods-signature-flamenco-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/BWSM-2-Ben-Woods-Signature-Flamenco-Acoustic-Electric-Guitar-Natural/L52103000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,799.99",
+
+            "savings": "$600.01 (25%)",
+
+            "maxSavingsMSRP": "$2,400.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.99",
+            "salePrice": "1799.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/ortega-bwsm-2-ben-woods-signature-flamenco-acoustic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Taylor 414ce-N Grand Auditorium Nylon-String Acoustic-Electric Guitar",
+            "productID": "site1prodL29996",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/taylor-414ce-n-grand-auditorium-nylon-string-acoustic-electric-guitar/l29996000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/taylor-414ce-n-grand-auditorium-nylon-string-acoustic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-N-Grand-Auditorium-Nylon-String-Acoustic-Electric-Guitar-Natural/L29996000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2699.0",
+            "salePrice": "2699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$57&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/taylor-414ce-n-grand-auditorium-nylon-string-acoustic-electric-guitar"
+            }
+        }
+    ],
+    "omnitureReportingData": {
+
+        "paginationNumber": "page 1",
+        "displayPerPage": "90",
+        "listFilters": "condition:new|category:classical &amp; nylon guitars|price:1500 - 2000",
+        "sortByType": "best selling"
+    }
+}

--- a/backend/seed/electric.raw.json
+++ b/backend/seed/electric.raw.json
@@ -1,0 +1,6804 @@
+{
+
+    "params": [{
+        "param": "Ns",
+        "value": "bS"
+    }, {
+        "param": "Nao",
+        "value": "0"
+    }, {
+        "param": "pageName",
+        "value": "category-page"
+    }, {
+        "param": "N",
+        "value": "100902 100511 100512 100902 500002 100511 100512"
+    }, {
+        "param": "recsPerPage",
+        "value": "90"
+    }],
+    "hasMoreBrandFacets": true,
+
+    "pagination": [{
+        "results": "1-90",
+        "display": "90",
+        "totalResults": "532",
+        "view": "",
+        "totalCompared": "0",
+        "currentPage": "1",
+        "pages": [
+
+            {
+                "page": "1",
+                "active": false
+            }
+
+            , {
+                "page": "2",
+
+                "active": true
+
+            }
+
+            , {
+                "page": "3",
+
+                "active": true
+
+            }
+
+            , {
+                "page": "4",
+
+                "active": true
+
+            }
+
+            , {
+                "page": "of",
+                "active": false
+            }
+
+            , {
+                "page": "6",
+                "active": true
+            }
+
+            , {
+                "page": "Next&gt;",
+                "active": true
+            }
+        ]
+    }],
+
+    "sortBy": [{
+            "value": "bM",
+            "name": "Best Match"
+        },
+        {
+            "value": "bS",
+            "name": "Best Sellers",
+            "selected": true
+        },
+
+        {
+            "value": "r",
+            "name": "Relevance"
+        },
+
+        {
+            "value": "oR",
+            "name": "Customer Ratings"
+        },
+
+        {
+            "value": "pHL",
+            "name": "Price - High to Low"
+        },
+        {
+            "value": "pLH",
+            "name": "Price - Low to High"
+        },
+        {
+            "value": "cD",
+            "name": "Newest First"
+        },
+        {
+            "value": "bN",
+            "name": "Brand Name A-Z"
+        }
+    ],
+    "facets": [{
+
+        "facetName": "Category",
+        "facetId": "500000",
+
+        "dimensionName": "category",
+
+        "state": "open",
+        "clearURL": "/category-page?N=100902+100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "hidden",
+
+        "selected": true,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Electric Guitars",
+                "facetValue": "500002",
+                "itemCount": "",
+                "seoURL": "/category-page?N=100902+100511+100512",
+
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Brands",
+        "facetId": "200000",
+
+        "dimensionName": "brand",
+
+        "state": "open",
+        "clearURL": "/electric-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "D&#039;Angelico",
+                "facetValue": "210064",
+                "itemCount": "36",
+                "seoURL": "/electric-guitars/dangelico--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Ernie Ball Music Man",
+                "facetValue": "201421",
+                "itemCount": "25",
+                "seoURL": "/electric-guitars/ernie-ball-music-man--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "ESP",
+                "facetValue": "200618",
+                "itemCount": "45",
+                "seoURL": "/electric-guitars/esp--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Fender",
+                "facetValue": "202612",
+                "itemCount": "83",
+                "seoURL": "/electric-guitars/fender--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Gibson",
+                "facetValue": "202616",
+                "itemCount": "46",
+                "seoURL": "/electric-guitars/gibson--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Gretsch Guitars",
+                "facetValue": "200886",
+                "itemCount": "30",
+                "seoURL": "/electric-guitars/gretsch-guitars--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Ibanez",
+                "facetValue": "202617",
+                "itemCount": "56",
+                "seoURL": "/electric-guitars/ibanez--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Jackson",
+                "facetValue": "201045",
+                "itemCount": "18",
+                "seoURL": "/electric-guitars/jackson--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "PRS",
+                "facetValue": "201539",
+                "itemCount": "22",
+                "seoURL": "/electric-guitars/prs--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Strandberg",
+                "facetValue": "3007347",
+                "itemCount": "33",
+                "seoURL": "/electric-guitars/strandberg--new?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Condition",
+        "facetId": "100901",
+
+        "dimensionName": "seeablecondition",
+
+        "state": "open",
+        "clearURL": "/electric-guitars?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": true,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "New",
+                "facetValue": "100902",
+                "itemCount": "",
+                "seoURL": "/electric-guitars?N=100511+100512",
+
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Price",
+        "facetId": "100501",
+
+        "dimensionName": "price",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "",
+
+        "selected": true,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "$1,500 - $2,000&nbsp;",
+                "facetValue": "100511",
+                "itemCount": "",
+                "seoURL": "",
+                "disabled": false,
+                "selected": true
+            },
+            {
+                "displayValue": "$2,000 - $3,000&nbsp;",
+                "facetValue": "100512",
+                "itemCount": "",
+                "seoURL": "",
+                "disabled": false,
+                "selected": true
+            }
+        ]
+    }, {
+
+        "facetName": "Customer Rating",
+        "facetId": "100401",
+
+        "dimensionName": "customerrating",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "<span class='stars small rate-10'></span>5 only",
+                "facetValue": "100402",
+                "itemCount": "123",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-8'></span>4 & up",
+                "facetValue": "100403",
+                "itemCount": "188",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-6'></span>3 & up",
+                "facetValue": "100404",
+                "itemCount": "194",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-4'></span>2 & up",
+                "facetValue": "100405",
+                "itemCount": "195",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "<span class='stars small rate-2'></span>1 & up",
+                "facetValue": "100406",
+                "itemCount": "200",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Performance Level",
+        "facetId": "407300",
+
+        "dimensionName": "performance_level",
+
+        "state": "open",
+        "clearURL": "/electric-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Intermediate",
+                "facetValue": "4294966673",
+                "itemCount": "4",
+                "seoURL": "/electric-guitars/new--intermediate?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Professional",
+                "facetValue": "4294966659",
+                "itemCount": "186",
+                "seoURL": "/electric-guitars/new--professional?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Color",
+        "facetId": "402500",
+
+        "dimensionName": "color",
+
+        "state": "open",
+        "clearURL": "/electric-guitars/new?N=100511+100512",
+
+        "seoFacet": true,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Black",
+                "facetValue": "4294967023",
+                "itemCount": "108",
+                "seoURL": "/electric-guitars/new--black?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Blonde",
+                "facetValue": "3006906",
+                "itemCount": "5",
+                "seoURL": "/electric-guitars/new--blonde?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Blue",
+                "facetValue": "4294967027",
+                "itemCount": "67",
+                "seoURL": "/electric-guitars/new--blue?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Brown",
+                "facetValue": "4294966739",
+                "itemCount": "2",
+                "seoURL": "/electric-guitars/new--brown?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Burst or Fade",
+                "facetValue": "4294962114",
+                "itemCount": "102",
+                "seoURL": "/electric-guitars/new--burst-or-fade?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Gold",
+                "facetValue": "4294963552",
+                "itemCount": "12",
+                "seoURL": "/electric-guitars/new--gold?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Green",
+                "facetValue": "4294967028",
+                "itemCount": "43",
+                "seoURL": "/electric-guitars/new--green?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Multi-Colored",
+                "facetValue": "4294967020",
+                "itemCount": "11",
+                "seoURL": "/electric-guitars/new--multi-colored?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Natural",
+                "facetValue": "4294966891",
+                "itemCount": "33",
+                "seoURL": "/electric-guitars/new--natural?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Orange",
+                "facetValue": "4294967024",
+                "itemCount": "7",
+                "seoURL": "/electric-guitars/new--orange?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Purple",
+                "facetValue": "4294965361",
+                "itemCount": "9",
+                "seoURL": "/electric-guitars/new--purple?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Red",
+                "facetValue": "4294967026",
+                "itemCount": "40",
+                "seoURL": "/electric-guitars/new--red?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Silver",
+                "facetValue": "4294965362",
+                "itemCount": "12",
+                "seoURL": "/electric-guitars/new--silver?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "White",
+                "facetValue": "4294967035",
+                "itemCount": "44",
+                "seoURL": "/electric-guitars/new--white?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Yellow",
+                "facetValue": "4294963547",
+                "itemCount": "1",
+                "seoURL": "/electric-guitars/new--yellow?N=100511+100512",
+
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Model",
+        "facetId": "3016952",
+
+        "dimensionName": "model",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Stratocaster",
+                "facetValue": "3017223",
+                "itemCount": "16",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Telecaster",
+                "facetValue": "3017014",
+                "itemCount": "10",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Les Paul",
+                "facetValue": "3017178",
+                "itemCount": "9",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Boden",
+                "facetValue": "3017140",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "E-II",
+                "facetValue": "3017234",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "RG",
+                "facetValue": "3018750",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Horizon",
+                "facetValue": "3017232",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Jazzmaster",
+                "facetValue": "3017297",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "M",
+                "facetValue": "3019006",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "SG",
+                "facetValue": "3018756",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "330",
+                "facetValue": "3018812",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Duo Jet",
+                "facetValue": "3017025",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "ASAT",
+                "facetValue": "3017231",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "AZ",
+                "facetValue": "3018749",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "DC",
+                "facetValue": "3018990",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Jet",
+                "facetValue": "3017224",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "JS",
+                "facetValue": "3018997",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "S",
+                "facetValue": "3018996",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "T3",
+                "facetValue": "3019033",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "360",
+                "facetValue": "3018843",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "CE 24",
+                "facetValue": "3016993",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Cutlass",
+                "facetValue": "3017363",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "EC",
+                "facetValue": "3018986",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Electromatic",
+                "facetValue": "3017355",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Merrow",
+                "facetValue": "3017325",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Nashville",
+                "facetValue": "3017238",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Salen",
+                "facetValue": "3017226",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "SS",
+                "facetValue": "3018988",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Vela",
+                "facetValue": "3017049",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "59",
+                "facetValue": "3018842",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "620",
+                "facetValue": "3018850",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Albert Lee",
+                "facetValue": "3016968",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Atlantic",
+                "facetValue": "3017246",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "ATZ",
+                "facetValue": "3017289",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "BB",
+                "facetValue": "3018785",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Bedford",
+                "facetValue": "3017311",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "BUZ",
+                "facetValue": "3016978",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Caribou",
+                "facetValue": "3017064",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Comanche",
+                "facetValue": "3017374",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Custom 24",
+                "facetValue": "3017298",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "DK24",
+                "facetValue": "3017194",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Explorer",
+                "facetValue": "3017302",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Flying V",
+                "facetValue": "3017265",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "FRX",
+                "facetValue": "3016974",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "H-150",
+                "facetValue": "3017116",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Horus",
+                "facetValue": "3017013",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Jaguar",
+                "facetValue": "3017314",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "John Mayer Silver Sky",
+                "facetValue": "3017200",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "John Scofield",
+                "facetValue": "3017389",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Les Paul Junior",
+                "facetValue": "3017011",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Majesty",
+                "facetValue": "3017031",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "MH",
+                "facetValue": "3018994",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "MK",
+                "facetValue": "3019004",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "N4",
+                "facetValue": "3018982",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Parallaxe",
+                "facetValue": "3017369",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "PT",
+                "facetValue": "3019008",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Revstar",
+                "facetValue": "3017036",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Setzer",
+                "facetValue": "3016970",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Standard 22",
+                "facetValue": "3016966",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Standard 24",
+                "facetValue": "3016980",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Steve Vai Jem",
+                "facetValue": "3020017",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Stringray Guitar",
+                "facetValue": "3019294",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Tennessee Rose",
+                "facetValue": "3017384",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Valentine",
+                "facetValue": "3017313",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Viper",
+                "facetValue": "3017045",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Number of Strings",
+        "facetId": "406800",
+
+        "dimensionName": "number_of_strings",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "6 String",
+                "facetValue": "4294966899",
+                "itemCount": "323",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "7 String",
+                "facetValue": "4294966585",
+                "itemCount": "29",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "8 String",
+                "facetValue": "4294965408",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "9 String",
+                "facetValue": "3015148",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "12 String",
+                "facetValue": "4294966596",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Pickup Configuration",
+        "facetId": "425800",
+
+        "dimensionName": "pickup_configuration",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "H",
+                "facetValue": "3015161",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "HH",
+                "facetValue": "4294963167",
+                "itemCount": "164",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "HHH",
+                "facetValue": "3009124",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "HS",
+                "facetValue": "4294963148",
+                "itemCount": "10",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "HSH",
+                "facetValue": "4294963149",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "HSS",
+                "facetValue": "4294963162",
+                "itemCount": "17",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "SS",
+                "facetValue": "4294962488",
+                "itemCount": "47",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "SSS",
+                "facetValue": "4294963156",
+                "itemCount": "44",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Country of Origin",
+        "facetId": "402700",
+
+        "dimensionName": "country_of_origin",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Canada",
+                "facetValue": "4294966526",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "China",
+                "facetValue": "4294966892",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Germany",
+                "facetValue": "4294966246",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Indonesia",
+                "facetValue": "4294966650",
+                "itemCount": "22",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Japan",
+                "facetValue": "4294966605",
+                "itemCount": "81",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mexico",
+                "facetValue": "4294966600",
+                "itemCount": "11",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "South Korea",
+                "facetValue": "4294966902",
+                "itemCount": "74",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "United States",
+                "facetValue": "4294966675",
+                "itemCount": "172",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Bridge Type",
+        "facetId": "401100",
+
+        "dimensionName": "bridge_type",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Fixed Bridge",
+                "facetValue": "4294966898",
+                "itemCount": "148",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Locking Tremolo",
+                "facetValue": "3015062",
+                "itemCount": "17",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Tremolo/Vibrato",
+                "facetValue": "4294966894",
+                "itemCount": "145",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Body Shape",
+        "facetId": "400900",
+
+        "dimensionName": "body_shape",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Double cutaway",
+                "facetValue": "4294966893",
+                "itemCount": "218",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Non-cutaway",
+                "facetValue": "4294966672",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Offset",
+                "facetValue": "3014768",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Single cutaway",
+                "facetValue": "4294966903",
+                "itemCount": "114",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "V",
+                "facetValue": "4294966592",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Artist Model",
+        "facetId": "3016869",
+
+        "dimensionName": "artist_model",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Albert Lee",
+                "facetValue": "3016887",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Ben Burnley",
+                "facetValue": "3016948",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Buz McGrath",
+                "facetValue": "3016872",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Gary Holt",
+                "facetValue": "3016933",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Joe Satriani",
+                "facetValue": "3016920",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Jon Donais",
+                "facetValue": "3020603",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Ken Susi",
+                "facetValue": "3016883",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Kirk Hammett",
+                "facetValue": "3016941",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Lincoln Brewster",
+                "facetValue": "3016950",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Lucas Mann",
+                "facetValue": "3020609",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Michael Sweet",
+                "facetValue": "3016916",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Mille Petrozza",
+                "facetValue": "3017823",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Neil Westfall",
+                "facetValue": "3017822",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Nuno Bettencourt",
+                "facetValue": "3016891",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Richie Kotzen",
+                "facetValue": "3016928",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Stephen Carpenter",
+                "facetValue": "3016884",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Steve Vai",
+                "facetValue": "3016923",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Tim Armstrong",
+                "facetValue": "3016936",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Troy Van Leeuwen",
+                "facetValue": "3016906",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Warren DeMartini",
+                "facetValue": "3016925",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Will Adler",
+                "facetValue": "3016935",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Series",
+        "facetId": "3017404",
+
+        "dimensionName": "series_new",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Albert Lee",
+                "facetValue": "3017415",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "American Original",
+                "facetValue": "3017467",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "American Professional",
+                "facetValue": "3017571",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "American Ultra",
+                "facetValue": "3017508",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Artist",
+                "facetValue": "3017405",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Classic",
+                "facetValue": "3017549",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Deluxe",
+                "facetValue": "3017461",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "E-II",
+                "facetValue": "3017536",
+                "itemCount": "8",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "EBMM Modern Classic",
+                "facetValue": "3017593",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Eclipse",
+                "facetValue": "3017465",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Excel",
+                "facetValue": "3017498",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Horizon",
+                "facetValue": "3017589",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "John Petrucci",
+                "facetValue": "3017599",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "LTD",
+                "facetValue": "3017551",
+                "itemCount": "9",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "M-2",
+                "facetValue": "3017576",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Metal",
+                "facetValue": "3017480",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Modern",
+                "facetValue": "3017452",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Original",
+                "facetValue": "3017475",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Prestige",
+                "facetValue": "3017568",
+                "itemCount": "13",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Pro-Mod",
+                "facetValue": "3017443",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "PRS Bolt On",
+                "facetValue": "3017598",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "S2 Series",
+                "facetValue": "3017591",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Special",
+                "facetValue": "3017550",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Standard",
+                "facetValue": "3017458",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Studio",
+                "facetValue": "3017460",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Traditional Pro V",
+                "facetValue": "3019701",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Valentine",
+                "facetValue": "3017495",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Left- or Right-Handed",
+        "facetId": "407000",
+
+        "dimensionName": "orientation",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Left Handed",
+                "facetValue": "4294966611",
+                "itemCount": "29",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Right Handed",
+                "facetValue": "4294966905",
+                "itemCount": "348",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Fingerboard Material",
+        "facetId": "3012709",
+
+        "dimensionName": "fingerboard_material",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Ebony",
+                "facetValue": "3012711",
+                "itemCount": "131",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Maple",
+                "facetValue": "3012712",
+                "itemCount": "83",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Pau Ferro",
+                "facetValue": "3012713",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Rosewood",
+                "facetValue": "3012714",
+                "itemCount": "137",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Wenge",
+                "facetValue": "3015189",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Other hardwood",
+                "facetValue": "3014246",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Composite Material",
+                "facetValue": "3015131",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Body Type",
+        "facetId": "401000",
+
+        "dimensionName": "body_type",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Hollow Body",
+                "facetValue": "4294966601",
+                "itemCount": "16",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Semi-Hollow",
+                "facetValue": "4294965901",
+                "itemCount": "34",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Solid Body",
+                "facetValue": "4294966900",
+                "itemCount": "312",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Accessories Included",
+        "facetId": "3016071",
+
+        "dimensionName": "accessories_included",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Case",
+                "facetValue": "3016073",
+                "itemCount": "6",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Gig bag",
+                "facetValue": "3016077",
+                "itemCount": "33",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Hardshell case",
+                "facetValue": "3016072",
+                "itemCount": "173",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Number of Frets",
+        "facetId": "3016006",
+
+        "dimensionName": "number_of_frets",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "20",
+                "facetValue": "3016010",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "20",
+                "facetValue": "3021749",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "21",
+                "facetValue": "3016017",
+                "itemCount": "28",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "22",
+                "facetValue": "3016020",
+                "itemCount": "192",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "23",
+                "facetValue": "3016019",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "24",
+                "facetValue": "3016015",
+                "itemCount": "125",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "27",
+                "facetValue": "3016009",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Nut Width",
+        "facetId": "3016021",
+
+        "dimensionName": "nut_width",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "1.38 in. (35 mm)",
+                "facetValue": "3016036",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.61 in. (40.9 mm)",
+                "facetValue": "3016065",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.62 in. (41.3 mm)",
+                "facetValue": "3016025",
+                "itemCount": "24",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.63 in. (41.4 mm)",
+                "facetValue": "3016057",
+                "itemCount": "7",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.64 in. (41.65 mm)",
+                "facetValue": "3016046",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.65 in. (42 mm)",
+                "facetValue": "3016026",
+                "itemCount": "72",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.653 in. (42 mm)",
+                "facetValue": "3016049",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.656 in. (42 mm)",
+                "facetValue": "3016051",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.66 in. (42.3 mm)",
+                "facetValue": "3016061",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.675 in. (42.5 mm)",
+                "facetValue": "3016043",
+                "itemCount": "4",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.68 in. (42.67 mm)",
+                "facetValue": "3016064",
+                "itemCount": "24",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.687 in. (42.8 mm)",
+                "facetValue": "3016022",
+                "itemCount": "44",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.69 in. (43 mm)",
+                "facetValue": "3016024",
+                "itemCount": "54",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.711 in. (43.45 mm)",
+                "facetValue": "3016056",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.75 in. (44.45 mm)",
+                "facetValue": "3016055",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.875 in. (47.62 mm)",
+                "facetValue": "3016032",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.89 in. (48 mm)",
+                "facetValue": "3016027",
+                "itemCount": "14",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.93 in. (49 mm)",
+                "facetValue": "3016038",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.94 in. (49.3 mm)",
+                "facetValue": "3016030",
+                "itemCount": "2",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "1.97 in. (50 mm)",
+                "facetValue": "3016039",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "2.10 in. (53.5 mm)",
+                "facetValue": "3016058",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "2.12 in. (54 mm)",
+                "facetValue": "3016044",
+                "itemCount": "3",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "2.16 in. (55 mm)",
+                "facetValue": "3016029",
+                "itemCount": "1",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Savings & Specials",
+        "facetId": "100201",
+
+        "dimensionName": "deals",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "Best Sellers",
+                "facetValue": "100206",
+                "itemCount": "142",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "On Sale",
+                "facetValue": "100202",
+                "itemCount": "11",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Price Drop",
+                "facetValue": "100203",
+                "itemCount": "5",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "New Arrivals",
+        "facetId": "100301",
+
+        "dimensionName": "newarrivals",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": true,
+        "methods": [
+
+            {
+                "displayValue": "New",
+                "facetValue": "100302",
+                "itemCount": "9",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            },
+            {
+                "displayValue": "Pre-Order",
+                "facetValue": "100303",
+                "itemCount": "19",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "Financing",
+        "facetId": "3000000",
+
+        "dimensionName": "financing",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "48 Month Financing",
+                "facetValue": "3014271",
+                "itemCount": "405",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }, {
+
+        "facetName": "In Stock",
+        "facetId": "3000002",
+
+        "dimensionName": "in stock",
+
+        "state": "open",
+
+        "seoFacet": false,
+
+        "displayStyle": "closeFacet",
+
+        "selected": false,
+        "multiSelect": false,
+        "methods": [
+
+            {
+                "displayValue": "Now In Stock",
+                "facetValue": "3024872",
+                "itemCount": "334",
+                "seoURL": "",
+                "disabled": false,
+                "selected": false
+            }
+        ]
+    }],
+    "categories": [
+
+        {
+            "displayName": "New Extended Range Electric Guitars",
+            "catId": "site1AAJ",
+            "dimVal": "500005",
+            "url": "/extended-range-electric-guitars/new?N=100511+100512",
+            "count": "47"
+        },
+        {
+            "displayName": "New Left-Handed Electric Guitars",
+            "catId": "site1AAN",
+            "dimVal": "500008",
+            "url": "/left-handed-electric-guitars/new?N=100511+100512",
+            "count": "26"
+        },
+        {
+            "displayName": "New Semi-Hollow and Hollow Body Electric Guitars",
+            "catId": "site1AAH",
+            "dimVal": "500004",
+            "url": "/semi-hollow-and-hollow-body-electric-guitars/new?N=100511+100512",
+            "count": "87"
+        },
+        {
+            "displayName": "New Solid Body Electric Guitars",
+            "catId": "site1AAG",
+            "dimVal": "500003",
+            "url": "/solid-body-electric-guitars/new?N=100511+100512",
+            "count": "377"
+        },
+        {
+            "displayName": "New Effects",
+            "catId": "site1HB",
+            "dimVal": "500489",
+            "url": "/effects/new?N=100511+100512",
+            "count": "4"
+        },
+        {
+            "displayName": "New Guitar Amplifiers",
+            "catId": "site1HAA",
+            "dimVal": "500424",
+            "url": "/guitar-amplifiers/new?N=100511+100512",
+            "count": "190"
+        }
+    ],
+    "products": [
+
+        {
+
+            "name": "Gibson Les Paul Studio Electric Guitar",
+            "productID": "site1prodL54490",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-studio-electric-guitar/l54490000003000",
+
+            "openBoxUrl": "/guitars/open-box-gibson-les-paul-studio-electric-guitar",
+
+            "path": "/guitars/gibson-les-paul-studio-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Studio-Electric-Guitar-Smokehouse-Burst/L54490000003000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "13",
+            "price": "$1,599.00",
+
+            "savings": "$150.00 (9%)",
+
+            "maxSavingsMSRP": "$1,749.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "4",
+                "productUrl": "/guitars/gibson-les-paul-studio-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Classic Electric Guitar",
+            "productID": "site1prodL54489",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-classic-electric-guitar/l54489000002000",
+
+            "openBoxUrl": "/guitars/open-box-gibson-les-paul-classic-electric-guitar",
+
+            "path": "/guitars/gibson-les-paul-classic-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Classic-Electric-Guitar-Heritage-Cherry-Sunburst/L54489000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "14",
+            "price": "$2,299.00",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$2,301.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "4",
+                "productUrl": "/guitars/gibson-les-paul-classic-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Traditional Pro V Satin Electric Guitar",
+            "productID": "site1prodL69588",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-traditional-pro-v-satin-electric-guitar/l69588000001000",
+
+            "openBoxUrl": "/guitars/open-box-gibson-les-paul-traditional-pro-v-satin-electric-guitar",
+
+            "path": "/guitars/gibson-les-paul-traditional-pro-v-satin-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Traditional-Pro-V-Satin-Electric-Guitar-Satin-Wine-Red/L69588000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "10",
+            "price": "$2,099.00",
+
+            "savings": "$1,100.00 (34%)",
+
+            "maxSavingsMSRP": "$3,199.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2099.0",
+            "salePrice": "2099.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$44&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-les-paul-traditional-pro-v-satin-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Slash Les Paul Standard Electric Guitar",
+            "productID": "site1prodL72812",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-slash-les-paul-standard-electric-guitar/l72812000003000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-slash-les-paul-standard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Slash-Les-Paul-Standard-Electric-Guitar-Anaconda-Burst/L72812000003000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "5",
+            "price": "$2,999.00",
+
+            "savings": "$400.00 (12%)",
+
+            "maxSavingsMSRP": "$3,399.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "5",
+                "productUrl": "/guitars/gibson-slash-les-paul-standard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Ultra Stratocaster Maple Fingerboard Electric Guitar",
+            "productID": "site1prodL69991",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-ultra-stratocaster-maple-fingerboard-electric-guitar/l69991000005000",
+
+            "openBoxUrl": "/guitars/open-box-fender-american-ultra-stratocaster-maple-fingerboard-electric-guitar",
+
+            "path": "/guitars/fender-american-ultra-stratocaster-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Ultra-Stratocaster-Maple-Fingerboard-Electric-Guitar-Cobra-Blue/L69991000005000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "8",
+            "price": "$2,099.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2099.99",
+            "salePrice": "2099.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$44&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "4",
+                "productUrl": "/guitars/fender-american-ultra-stratocaster-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Standard '50s Electric Guitar",
+            "productID": "site1prodL54575",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-standard-50s-electric-guitar/l54575000003000",
+
+            "openBoxUrl": "/guitars/open-box-gibson-les-paul-standard-50s-electric-guitar",
+
+            "path": "/guitars/gibson-les-paul-standard-50s-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Standard-50s-Electric-Guitar-Tobacco-Burst/L54575000003000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "13",
+            "price": "$2,699.00",
+
+            "savings": "$200.00 (7%)",
+
+            "maxSavingsMSRP": "$2,899.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2699.0",
+            "salePrice": "2699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$57&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/gibson-les-paul-standard-50s-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Standard '60s Electric Guitar",
+            "productID": "site1prodL54578",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-standard-60s-electric-guitar/l54578000001000",
+
+            "openBoxUrl": "/guitars/open-box-gibson-les-paul-standard-60s-electric-guitar",
+
+            "path": "/guitars/gibson-les-paul-standard-60s-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Standard-60s-Electric-Guitar-Iced-Tea/L54578000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "12",
+            "price": "$2,699.00",
+
+            "savings": "$200.00 (7%)",
+
+            "maxSavingsMSRP": "$2,899.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2699.0",
+            "salePrice": "2699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$57&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/gibson-les-paul-standard-60s-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson SG Standard '61 Maestro Vibrola Electric Guitar",
+            "productID": "site1prodL54581",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-sg-standard-61-maestro-vibrola-electric-guitar/l54581000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-sg-standard-61-maestro-vibrola-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/SG-Standard-61-Maestro-Vibrola-Electric-Guitar-Vintage-Cherry/L54581000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "7",
+            "price": "$2,199.00",
+
+            "savings": "$100.00 (4%)",
+
+            "maxSavingsMSRP": "$2,299.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2199.0",
+            "salePrice": "2199.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-sg-standard-61-maestro-vibrola-electric-guitar"
+            }
+        },
+        {
+
+            "name": "D'Angelico Excel Series SS Semi-Hollow Electric Guitar with Stopbar Tailpiece",
+            "productID": "site1prodL13200",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/dangelico-excel-series-ss-semi-hollow-electric-guitar-with-stopbar-tailpiece/l13200000005000",
+
+            "openBoxUrl": "/guitars/open-box-dangelico-excel-series-ss-semi-hollow-electric-guitar-with-stopbar-tailpiece/l13200",
+
+            "path": "/guitars/dangelico-excel-series-ss-semi-hollow-electric-guitar-with-stopbar-tailpiece/l13200",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Excel-Series-SS-Semi-Hollow-Electric-Guitar-with-Stopbar-Tailpiece-Black/L13200000005000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "12",
+            "price": "$1,799.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.99",
+            "salePrice": "1799.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/dangelico-excel-series-ss-semi-hollow-electric-guitar-with-stopbar-tailpiece/l13200"
+            }
+        },
+        {
+
+            "name": "Fender 60th Anniversary Jaguar Electric Guitar",
+            "productID": "site1prodL91870",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-60th-anniversary-jaguar-electric-guitar/l91870000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-60th-anniversary-jaguar-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/60th-Anniversary-Jaguar-Electric-Guitar-Mystic-Dakota-Red/L91870000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,499.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2499.99",
+            "salePrice": "2499.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$53&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/fender-60th-anniversary-jaguar-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Deluxe '70s Electric Guitar",
+            "productID": "site1prodL83996",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-deluxe-70s-electric-guitar/l83996000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-les-paul-deluxe-70s-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Deluxe-70s-Electric-Guitar-Cherry-Sunburst/L83996000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,699.00",
+
+            "savings": "$200.00 (7%)",
+
+            "maxSavingsMSRP": "$2,899.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2699.0",
+            "salePrice": "2699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$57&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-les-paul-deluxe-70s-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Rickenbacker 620 Electric Guitar",
+            "productID": "site1prod513652",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/rickenbacker-620-electric-guitar/513652000204000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/rickenbacker-620-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/620-Electric-Guitar-Mapleglo/513652000204000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "Unique design and deluxe features combine in one of the hottest rockers of all time!",
+            "rating": "10",
+            "reviews": "69",
+            "price": "Email for Price",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Pre-Order",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "",
+            "salePrice": "",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/rickenbacker-620-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Traditional Pro V Flame Top Electric Guitar",
+            "productID": "site1prodL69587",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-traditional-pro-v-flame-top-electric-guitar/l69587000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-les-paul-traditional-pro-v-flame-top-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Traditional-Pro-V-Flame-Top-Electric-Guitar-Blueberry-Burst/L69587000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "6",
+            "price": "$2,999.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.0",
+            "salePrice": "2999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-les-paul-traditional-pro-v-flame-top-electric-guitar"
+            }
+        },
+        {
+
+            "name": "EVH Striped Series Frankie Electric Guitar",
+            "productID": "site1prodL73032",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/evh-striped-series-frankie-electric-guitar/l73032000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/evh-striped-series-frankie-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Striped-Series-Frankie-Electric-Guitar-Red-with-Black-and-White-Stripes-Relic/L73032000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "7",
+            "price": "$1,999.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/evh-striped-series-frankie-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson SG Standard '61 Electric Guitar",
+            "productID": "site1prodL54585",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-sg-standard-61-electric-guitar/l54585000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-sg-standard-61-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/SG-Standard-61-Electric-Guitar-Vintage-Cherry/L54585000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "24",
+            "price": "$1,999.00",
+
+            "savings": "$100.00 (5%)",
+
+            "maxSavingsMSRP": "$2,099.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-sg-standard-61-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson SG Standard Electric Guitar",
+            "productID": "site1prodL54573",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-sg-standard-electric-guitar/l54573000002000",
+
+            "openBoxUrl": "/guitars/open-box-gibson-sg-standard-electric-guitar",
+
+            "path": "/guitars/gibson-sg-standard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/SG-Standard-Electric-Guitar-Ebony/L54573000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "6",
+            "price": "$1,699.00",
+
+            "savings": "$50.00 (3%)",
+
+            "maxSavingsMSRP": "$1,749.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-sg-standard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Rickenbacker 360 12-String Electric Guitar",
+            "productID": "site1prod513659",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/rickenbacker-360-12-string-electric-guitar/513659000204000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/rickenbacker-360-12-string-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/360-12-String-Electric-Guitar-Mapleglo/513659000204000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "The world&#39;s most popular 12-string for nearly 40 years.",
+            "rating": "9",
+            "reviews": "85",
+            "price": "Email for Price",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Pre-Order",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "",
+            "salePrice": "",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/rickenbacker-360-12-string-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Rickenbacker 330 Electric Guitar",
+            "productID": "site1prod513651",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/rickenbacker-330-electric-guitar/513651000084000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/rickenbacker-330-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/330-Electric-Guitar-Jetglo/513651000084000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "A rock classic from the &#39;60s that&#39;s still a favorite today.",
+            "rating": "10",
+            "reviews": "111",
+            "price": "Email for Price",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Pre-Order",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "",
+            "salePrice": "",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/rickenbacker-330-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gretsch Guitars G5191 Tim Armstrong Electromatic Hollowbody Electric Guitar",
+            "productID": "site1prod423446",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gretsch-guitars-g5191-tim-armstrong-electromatic-hollowbody-electric-guitar/423446000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gretsch-guitars-g5191-tim-armstrong-electromatic-hollowbody-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/G5191-Tim-Armstrong-Electromatic-Hollowbody-Electric-Guitar-Black/423446000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "That full-bodied piano-like sound that Tim loves is generated by parallel tone bars and a sound post mounted...",
+            "rating": "10",
+            "reviews": "8",
+            "price": "$1,599.99",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$1,601.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.99",
+            "salePrice": "1599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gretsch-guitars-g5191-tim-armstrong-electromatic-hollowbody-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Rickenbacker 330/12 Electric Guitar",
+            "productID": "site1prod513660",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/rickenbacker-330-12-electric-guitar/513660000003000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/rickenbacker-330-12-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/330-12-Electric-Guitar-Fireglo/513660000003000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "Sounds of The Byrds and The Beatles!",
+            "rating": "9",
+            "reviews": "11",
+            "price": "Email for Price",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Pre-Order",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "",
+            "salePrice": "",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/rickenbacker-330-12-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Studio Limited-Edition Electric Guitar",
+            "productID": "site1prodL76588",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-studio-limited-edition-electric-guitar/l76588000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-les-paul-studio-limited-edition-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Studio-Limited-Edition-Electric-Guitar-Manhattan-Midnight/L76588000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,599.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-les-paul-studio-limited-edition-electric-guitar"
+            }
+        },
+        {
+
+            "name": "PRS CE 24 Electric Guitar",
+            "productID": "site1prodJ30024",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/prs-ce-24-electric-guitar/j30024000026000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/prs-ce-24-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/CE-24-Electric-Guitar-Black-Amber/J30024000026000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "16",
+            "price": "Starting&nbsp;at $1,999.00",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$2,301.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "11",
+                "productUrl": "/guitars/prs-ce-24-electric-guitar"
+            }
+        },
+        {
+
+            "name": "PRS S2 McCarty 594 Thinline Electric Guitar",
+            "productID": "site1prodL73003",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/prs-s2-mccarty-594-thinline-electric-guitar/l73003000008000",
+
+            "openBoxUrl": "/guitars/open-box-prs-s2-mccarty-594-thinline-electric-guitar",
+
+            "path": "/guitars/prs-s2-mccarty-594-thinline-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/S2-McCarty-594-Thinline-Electric-Guitar-Mahi-Blue/L73003000008000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$1,699.00",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$1,701.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.0",
+            "salePrice": "1699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "7",
+                "productUrl": "/guitars/prs-s2-mccarty-594-thinline-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Jackson Concept Series Rhoads RR24MG Ebony Fingerboard Electric Guitar",
+            "productID": "site1prodL85496",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/jackson-concept-series-rhoads-rr24mg-ebony-fingerboard-electric-guitar/l85496000001000",
+
+            "openBoxUrl": "/guitars/open-box-jackson-concept-series-rhoads-rr24mg-ebony-fingerboard-electric-guitar",
+
+            "path": "/guitars/jackson-concept-series-rhoads-rr24mg-ebony-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Concept-Series-Rhoads-RR24MG-Ebony-Fingerboard-Electric-Guitar-Gloss-Black/L85496000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,599.99",
+
+            "regularPrice": "$1,899.99",
+
+            "savings": "$835.89 (34%)",
+
+            "maxSavingsMSRP": "$2,435.88",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Sale",
+            "stickerClass": "stickerEmphasis",
+            "compared": false,
+            "onsale": "true",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1899.99",
+            "salePrice": "1599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/jackson-concept-series-rhoads-rr24mg-ebony-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Professional II Telecaster Maple Fingerboard Electric Guitar",
+            "productID": "site1prodL78119",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-professional-ii-telecaster-maple-fingerboard-electric-guitar/l78119000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-professional-ii-telecaster-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Telecaster-Maple-Fingerboard-Electric-Guitar-Black/L78119000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "Starting&nbsp;at $1,699.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.99",
+            "salePrice": "1699.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "4",
+                "productUrl": "/guitars/fender-american-professional-ii-telecaster-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Professional II Stratocaster HSS Rosewood Fingerboard Electric Guitar",
+            "productID": "site1prodL78116",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-professional-ii-stratocaster-hss-rosewood-fingerboard-electric-guitar/l78116000004000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-professional-ii-stratocaster-hss-rosewood-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Stratocaster-HSS-Rosewood-Fingerboard-Electric-Guitar-Mercury/L78116000004000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$1,749.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1749.99",
+            "salePrice": "1749.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$37&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "5",
+                "productUrl": "/guitars/fender-american-professional-ii-stratocaster-hss-rosewood-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Professional II Stratocaster Maple Fingerboard Electric Guitar",
+            "productID": "site1prodL78115",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-professional-ii-stratocaster-maple-fingerboard-electric-guitar/l78115000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-professional-ii-stratocaster-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Stratocaster-Maple-Fingerboard-Electric-Guitar-3-Color-Sunburst/L78115000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$1,699.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.99",
+            "salePrice": "1699.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "6",
+                "productUrl": "/guitars/fender-american-professional-ii-stratocaster-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Professional II Telecaster Rosewood Fingerboard Electric Guitar",
+            "productID": "site1prodL78043",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-professional-ii-telecaster-rosewood-fingerboard-electric-guitar/l78043000002000",
+
+            "openBoxUrl": "/guitars/open-box-fender-american-professional-ii-telecaster-rosewood-fingerboard-electric-guitar",
+
+            "path": "/guitars/fender-american-professional-ii-telecaster-rosewood-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Telecaster-Rosewood-Fingerboard-Electric-Guitar-Olympic-White/L78043000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "3",
+            "price": "$1,699.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.99",
+            "salePrice": "1699.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "5",
+                "productUrl": "/guitars/fender-american-professional-ii-telecaster-rosewood-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Professional II Stratocaster Rosewood Fingerboard Electric Guitar",
+            "productID": "site1prodL78030",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-professional-ii-stratocaster-rosewood-fingerboard-electric-guitar/l78030000004000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-professional-ii-stratocaster-rosewood-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Stratocaster-Rosewood-Fingerboard-Electric-Guitar-Miami-Blue/L78030000004000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "4",
+            "price": "$1,699.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.99",
+            "salePrice": "1699.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "6",
+                "productUrl": "/guitars/fender-american-professional-ii-stratocaster-rosewood-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Heritage Artisan Aged Collection H-150 Electric Guitar",
+            "productID": "site1prodL72734",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/heritage-artisan-aged-collection-h-150-electric-guitar/l72734000003000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/heritage-artisan-aged-collection-h-150-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Artisan-Aged-Collection-H-150-Electric-Guitar-Ebony/L72734000003000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$2,499.00",
+
+            "savings": "$1.00 (0%)",
+
+            "maxSavingsMSRP": "$2,500.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2499.0",
+            "salePrice": "2499.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$53&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/heritage-artisan-aged-collection-h-150-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Brent Mason Telecaster Electric Guitar",
+            "productID": "site1prodL76581",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-brent-mason-telecaster-electric-guitar/l76581000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-brent-mason-telecaster-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Brent-Mason-Telecaster-Electric-Guitar-Primer-Gray/L76581000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,899.99",
+
+            "savings": "$50.00 (2%)",
+
+            "maxSavingsMSRP": "$2,949.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2899.99",
+            "salePrice": "2899.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$61&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-brent-mason-telecaster-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender 70th Anniversary Esquire Maple Fingerboard Electric Guitar",
+            "productID": "site1prodL72239",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-70th-anniversary-esquire-maple-fingerboard-electric-guitar/l72239000003000",
+
+            "openBoxUrl": "/guitars/open-box-fender-70th-anniversary-esquire-maple-fingerboard-electric-guitar",
+
+            "path": "/guitars/fender-70th-anniversary-esquire-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/70th-Anniversary-Esquire-Maple-Fingerboard-Electric-Guitar-Surf-Green/L72239000003000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "Starting&nbsp;at $1,999.99",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$2,051.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "4",
+                "productUrl": "/guitars/fender-70th-anniversary-esquire-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Original '60s Telecaster Rosewood Fingerboard Electric Guitar",
+            "productID": "site1prodK48524",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-original-60s-telecaster-rosewood-fingerboard-electric-guitar/k48524000004000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-original-60s-telecaster-rosewood-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Original-60s-Telecaster-Rosewood-Fingerboard-Electric-Guitar-Burgundy-Mist-Metallic/K48524000004000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "6",
+            "price": "$2,149.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2149.99",
+            "salePrice": "2149.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$45&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/fender-american-original-60s-telecaster-rosewood-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Ultra Stratocaster HSS Maple Fingerboard Electric Guitar",
+            "productID": "site1prodL69975",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-ultra-stratocaster-hss-maple-fingerboard-electric-guitar/l69975000004000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-ultra-stratocaster-hss-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Ultra-Stratocaster-HSS-Maple-Fingerboard-Electric-Guitar-Texas-Tea/L69975000004000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "4",
+            "price": "$2,149.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2149.99",
+            "salePrice": "2149.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$45&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/fender-american-ultra-stratocaster-hss-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Junior Electric Guitar",
+            "productID": "site1prodL54579",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-junior-electric-guitar/l54579000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-les-paul-junior-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Junior-Electric-Guitar-Vintage-Tobacco/L54579000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "7",
+            "price": "$1,599.00",
+
+            "savings": "$522.00 (25%)",
+
+            "maxSavingsMSRP": "$2,121.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-les-paul-junior-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Jimmy Page Telecaster Electric Guitar",
+            "productID": "site1prodL48010",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-jimmy-page-telecaster-electric-guitar/l48010000001000",
+
+            "openBoxUrl": "/guitars/open-box-fender-jimmy-page-telecaster-electric-guitar",
+
+            "path": "/guitars/fender-jimmy-page-telecaster-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Jimmy-Page-Telecaster-Electric-Guitar-Natural/L48010000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "13",
+            "price": "$1,599.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.99",
+            "salePrice": "1599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-jimmy-page-telecaster-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Original '60s Stratocaster Rosewood Fingerboard Electric Guitar",
+            "productID": "site1prodK48545",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-original-60s-stratocaster-rosewood-fingerboard-electric-guitar/k48545000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-original-60s-stratocaster-rosewood-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Original-60s-Stratocaster-Rosewood-Fingerboard-Electric-Guitar-3-Color-Sunburst/K48545000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$2,099.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2099.99",
+            "salePrice": "2099.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$44&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/fender-american-original-60s-stratocaster-rosewood-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Original '50s Stratocaster Maple Fingerboard Electric Guitar",
+            "productID": "site1prodK48472",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-original-50s-stratocaster-maple-fingerboard-electric-guitar/k48472000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-original-50s-stratocaster-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Original-50s-Stratocaster-Maple-Fingerboard-Electric-Guitar-White-Blonde/K48472000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "9",
+            "price": "Starting&nbsp;at $2,099.99",
+
+            "savings": "$100.00 (4%)",
+
+            "maxSavingsMSRP": "$2,249.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2099.99",
+            "salePrice": "2099.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$44&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/fender-american-original-50s-stratocaster-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "PRS S2 Standard 24 Electric Guitar",
+            "productID": "site1prodJ50426",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/prs-s2-standard-24-electric-guitar/j50426000010001",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/prs-s2-standard-24-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/S2-Standard-24-Electric-Guitar-Black-Black-Pickguard/J50426000010001-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "8",
+            "price": "$1,649.00",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$1,651.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1649.0",
+            "salePrice": "1649.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$35&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/prs-s2-standard-24-electric-guitar"
+            }
+        },
+        {
+
+            "name": "ESP LTD Kirk Hammett Signature White Zombie Electric Guitar",
+            "productID": "site1prodJ03791",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/esp-ltd-kirk-hammett-signature-white-zombie-electric-guitar/j03791000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/esp-ltd-kirk-hammett-signature-white-zombie-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/LTD-Kirk-Hammett-Signature-White-Zombie-Electric-Guitar-Graphic/J03791000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "6",
+            "price": "$1,599.00",
+
+            "savings": "$614.00 (28%)",
+
+            "maxSavingsMSRP": "$2,213.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/esp-ltd-kirk-hammett-signature-white-zombie-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Troy Van Leeuwen Jazzmaster Electric Guitar",
+            "productID": "site1prodJ05497",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-troy-van-leeuwen-jazzmaster-electric-guitar/j05497000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-troy-van-leeuwen-jazzmaster-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Troy-Van-Leeuwen-Jazzmaster-Electric-Guitar-Oxblood/J05497000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "6",
+            "price": "$1,599.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.99",
+            "salePrice": "1599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-troy-van-leeuwen-jazzmaster-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Artist Series Eric Clapton Stratocaster Electric Guitar",
+            "productID": "site1prod510637",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-artist-series-eric-clapton-stratocaster-electric-guitar/510637000847000",
+
+            "openBoxUrl": "/guitars/open-box-fender-artist-series-eric-clapton-stratocaster-electric-guitar",
+
+            "path": "/guitars/fender-artist-series-eric-clapton-stratocaster-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Artist-Series-Eric-Clapton-Stratocaster-Electric-Guitar-Pewter/510637000847000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "Updated version of the Clapton Signature Strat features a special soft &quot;V&quot; shape neck, Vintage Noiseless...",
+            "rating": "10",
+            "reviews": "133",
+            "price": "$1,999.99",
+
+            "savings": "$50.00 (2%)",
+
+            "maxSavingsMSRP": "$2,049.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "4",
+                "productUrl": "/guitars/fender-artist-series-eric-clapton-stratocaster-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender 60th Anniversary American Ultra Luxe Jaguar Electric Guitar",
+            "productID": "site1prodL91866",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-60th-anniversary-american-ultra-luxe-jaguar-electric-guitar/l91866000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-60th-anniversary-american-ultra-luxe-jaguar-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/60th-Anniversary-American-Ultra-Luxe-Jaguar-Electric-Guitar-Texas-Tea/L91866000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,499.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2499.99",
+            "salePrice": "2499.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$53&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-60th-anniversary-american-ultra-luxe-jaguar-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Showcase Telecaster Rosewood Fingerboard Limited-Edition Electric Guitar",
+            "productID": "site1prodL74900",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-showcase-telecaster-rosewood-fingerboard-limited-edition-electric-guitar/l74900000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-showcase-telecaster-rosewood-fingerboard-limited-edition-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Showcase-Telecaster-Rosewood-Fingerboard-Limited-Edition-Electric-Guitar-Sky-Burst-Metallic/L74900000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$1,749.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1749.99",
+            "salePrice": "1749.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$37&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-american-showcase-telecaster-rosewood-fingerboard-limited-edition-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Charvel Henrik Danhage Limited-Edition Signature Pro-Mod So-Cal Style 1 Electric Guitar",
+            "productID": "site1prodL89322",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/charvel-henrik-danhage-limited-edition-signature-pro-mod-so-cal-style-1-electric-guitar/l89322000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/charvel-henrik-danhage-limited-edition-signature-pro-mod-so-cal-style-1-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Henrik-Danhage-Limited-Edition-Signature-Pro-Mod-So-Cal-Style-1-Electric-Guitar-White-Relic/L89322000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,699.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1699.99",
+            "salePrice": "1699.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$36&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/charvel-henrik-danhage-limited-edition-signature-pro-mod-so-cal-style-1-electric-guitar"
+            }
+        },
+        {
+
+            "name": "PRS CE 24 Semi-Hollow Electric Guitar",
+            "productID": "site1prodL39552",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/prs-ce-24-semi-hollow-electric-guitar/l39552000018000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/prs-ce-24-semi-hollow-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/CE-24-Semi-Hollow-Electric-Guitar-Black-Amber/L39552000018000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,399.00",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$2,401.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2399.0",
+            "salePrice": "2399.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$50&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "10",
+                "productUrl": "/guitars/prs-ce-24-semi-hollow-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Jackson Pro Series Signature Jeff Loomis Kelly Ash",
+            "productID": "site1prodL86878",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/jackson-pro-series-signature-jeff-loomis-kelly-ash/l86878000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/jackson-pro-series-signature-jeff-loomis-kelly-ash",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Pro-Series-Signature-Jeff-Loomis-Kelly-Ash-Black/L86878000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,599.99",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$1,601.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.99",
+            "salePrice": "1599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/jackson-pro-series-signature-jeff-loomis-kelly-ash"
+            }
+        },
+        {
+
+            "name": "PRS Fiore Electric Guitar",
+            "productID": "site1prodL82094",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/prs-fiore-electric-guitar/l82094000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/prs-fiore-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Fiore-Electric-Guitar-Sugar-Moon/L82094000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$2,449.00",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$2,451.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2449.0",
+            "salePrice": "2449.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$52&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/prs-fiore-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gretsch Guitars G6228TG-PE Players Edition Jet BT with Bigsby and Gold Hardware",
+            "productID": "site1prodL82090",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gretsch-guitars-g6228tg-pe-players-edition-jet-bt-with-bigsby-and-gold-hardware/l82090000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gretsch-guitars-g6228tg-pe-players-edition-jet-bt-with-bigsby-and-gold-hardware",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/G6228TG-PE-Players-Edition-Jet-BT-with-Bigsby-and-Gold-Hardware-Cadillac-Green/L82090000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,999.99",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$3,001.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2999.99",
+            "salePrice": "2999.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$63&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/gretsch-guitars-g6228tg-pe-players-edition-jet-bt-with-bigsby-and-gold-hardware"
+            }
+        },
+        {
+
+            "name": "Fender American Ultra Luxe Stratocaster HSS Floyd Rose Rosewood Fingerboard Electric Guitar",
+            "productID": "site1prodL81806",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-ultra-luxe-stratocaster-hss-floyd-rose-rosewood-fingerboard-electric-guitar/l81806000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-ultra-luxe-stratocaster-hss-floyd-rose-rosewood-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Ultra-Luxe-Stratocaster-HSS-Floyd-Rose-Rosewood-Fingerboard-Electric-Guitar-Mystic-Black/L81806000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,599.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2599.99",
+            "salePrice": "2599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$55&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-american-ultra-luxe-stratocaster-hss-floyd-rose-rosewood-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Jackson Pro Series Rhoads RR24",
+            "productID": "site1prodL81226",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/jackson-pro-series-rhoads-rr24/l81226000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/jackson-pro-series-rhoads-rr24",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Pro-Series-Rhoads-RR24-Maul-Crackle/L81226000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,549.99",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$1,551.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1549.99",
+            "salePrice": "1549.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$33&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/jackson-pro-series-rhoads-rr24"
+            }
+        },
+        {
+
+            "name": "Jackson Pro Series Signature Misha Mansoor Juggernaut ET7",
+            "productID": "site1prodL81118",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/jackson-pro-series-signature-misha-mansoor-juggernaut-et7/l81118000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/jackson-pro-series-signature-misha-mansoor-juggernaut-et7",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Pro-Series-Signature-Misha-Mansoor-Juggernaut-ET7-Gulf-Blue/L81118000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,569.99",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$1,571.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1569.99",
+            "salePrice": "1569.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$33&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/jackson-pro-series-signature-misha-mansoor-juggernaut-et7"
+            }
+        },
+        {
+
+            "name": "Jackson Pro Series Soloist SL3R",
+            "productID": "site1prodL81092",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/jackson-pro-series-soloist-sl3r/l81092000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/jackson-pro-series-soloist-sl3r",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Pro-Series-Soloist-SL3R-Mirror/L81092000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,599.99",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$1,601.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.99",
+            "salePrice": "1599.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/jackson-pro-series-soloist-sl3r"
+            }
+        },
+        {
+
+            "name": "Fender American Showcase QMT Telecaster Maple Fingerboard Electric Guitar",
+            "productID": "site1prodL73018",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-showcase-qmt-telecaster-maple-fingerboard-electric-guitar/l73018000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-showcase-qmt-telecaster-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Showcase-QMT-Telecaster-Maple-Fingerboard-Electric-Guitar-Aqua-Marine-Metallic/L73018000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,769.99",
+
+            "regularPrice": "$2,199.99",
+
+            "savings": "$430.02 (20%)",
+
+            "maxSavingsMSRP": "$2,200.01",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Sale",
+            "stickerClass": "stickerEmphasis",
+            "compared": false,
+            "onsale": "true",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2199.99",
+            "salePrice": "1769.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$37&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-american-showcase-qmt-telecaster-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Classic Left-Handed Electric Guitar",
+            "productID": "site1prodL78256",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-classic-left-handed-electric-guitar/l78256000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-les-paul-classic-left-handed-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Classic-Left-Handed-Electric-Guitar-Transparent-Cherry/L78256000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$2,299.00",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$2,301.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2299.0",
+            "salePrice": "2299.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/gibson-les-paul-classic-left-handed-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Professional II Telecaster Deluxe Rosewood Fingerboard Electric Guitar",
+            "productID": "site1prodL78049",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-professional-ii-telecaster-deluxe-rosewood-fingerboard-electric-guitar/l78049000003000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-professional-ii-telecaster-deluxe-rosewood-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Telecaster-Deluxe-Rosewood-Fingerboard-Electric-Guitar-Dark-Night/L78049000003000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,749.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1749.99",
+            "salePrice": "1749.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$37&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/fender-american-professional-ii-telecaster-deluxe-rosewood-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Professional II Roasted Pine Telecaster Electric Guitar",
+            "productID": "site1prodL78016",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-professional-ii-roasted-pine-telecaster-electric-guitar/l78016000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-professional-ii-roasted-pine-telecaster-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Roasted-Pine-Telecaster-Electric-Guitar-Natural/L78016000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,799.99",
+
+            "savings": "$50.00 (3%)",
+
+            "maxSavingsMSRP": "$1,849.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.99",
+            "salePrice": "1799.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/fender-american-professional-ii-roasted-pine-telecaster-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Professional II Roasted Pine Stratocaster Maple Fingerboard Electric Guitar",
+            "productID": "site1prodL78015",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-professional-ii-roasted-pine-stratocaster-maple-fingerboard-electric-guitar/l78015000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-american-professional-ii-roasted-pine-stratocaster-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Roasted-Pine-Stratocaster-Maple-Fingerboard-Electric-Guitar-Sienna-Sunburst/L78015000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "2",
+            "price": "$1,799.99",
+
+            "savings": "$50.00 (3%)",
+
+            "maxSavingsMSRP": "$1,849.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.99",
+            "salePrice": "1799.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/fender-american-professional-ii-roasted-pine-stratocaster-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gretsch Guitars G6128T Players Edition Jet DS with Bigsby",
+            "productID": "site1prodL77918",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gretsch-guitars-g6128t-players-edition-jet-ds-with-bigsby/l77918000004000",
+
+            "openBoxUrl": "/guitars/open-box-gretsch-guitars-g6128t-players-edition-jet-ds-with-bigsby",
+
+            "path": "/guitars/gretsch-guitars-g6128t-players-edition-jet-ds-with-bigsby",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/G6128T-Players-Edition-Jet-DS-with-Bigsby-Sahara-Metallic/L77918000004000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,899.99",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$2,901.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2899.99",
+            "salePrice": "2899.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$61&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "4",
+                "productUrl": "/guitars/gretsch-guitars-g6128t-players-edition-jet-ds-with-bigsby"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Studio Dark Limited-Edition Electric Guitar",
+            "productID": "site1prodL76595",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-studio-dark-limited-edition-electric-guitar/l76595000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-les-paul-studio-dark-limited-edition-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Studio-Dark-Limited-Edition-Electric-Guitar-Ebony/L76595000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "7",
+            "reviews": "3",
+            "price": "$1,599.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-les-paul-studio-dark-limited-edition-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson SG Standard Dark Limited-Edition Electric Guitar",
+            "productID": "site1prodL76594",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-sg-standard-dark-limited-edition-electric-guitar/l76594000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-sg-standard-dark-limited-edition-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/SG-Standard-Dark-Limited-Edition-Electric-Guitar-Cherry/L76594000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,599.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-sg-standard-dark-limited-edition-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Flying V Mirror Limited-Edition Electric Guitar",
+            "productID": "site1prodL76583",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-flying-v-mirror-limited-edition-electric-guitar/l76583000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-flying-v-mirror-limited-edition-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Flying-V-Mirror-Limited-Edition-Electric-Guitar-Ebony/L76583000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,999.00",
+
+            "savings": "$100.00 (5%)",
+
+            "maxSavingsMSRP": "$2,099.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.0",
+            "salePrice": "1999.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$42&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-flying-v-mirror-limited-edition-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Legator N8FX Ninja X 8 8-String Electric Guitar",
+            "productID": "site1prodL75584",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/legator-n8fx-ninja-x-8-multi-scale-electric-guitar/l75584000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/legator-n8fx-ninja-x-8-multi-scale-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/N8FX-Ninja-X-8-8-String-Electric-Guitar-Amethyst/L75584000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "8",
+            "reviews": "1",
+            "price": "$1,900.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "10% off w/ guitarfest",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1900.0",
+            "salePrice": "1900.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/legator-n8fx-ninja-x-8-multi-scale-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Legator N7FX Ninja X 7 Multi-Scale Electric Guitar",
+            "productID": "site1prodL75564",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/legator-n7fx-ninja-x-7-multi-scale-electric-guitar/l75564000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/legator-n7fx-ninja-x-7-multi-scale-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/N7FX-Ninja-X-7-Multi-Scale-Electric-Guitar-Amethyst/L75564000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "1",
+            "price": "$1,800.00",
+
+            "savings": "$1.00 (0%)",
+
+            "maxSavingsMSRP": "$1,801.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "10% off w/ guitarfest",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1800.0",
+            "salePrice": "1800.0",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/legator-n7fx-ninja-x-7-multi-scale-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson ES-335 Satin Semi-Hollow Electric Guitar",
+            "productID": "site1prodL74688",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-es-335-satin-semi-hollow-electric-guitar/l74688000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-es-335-satin-semi-hollow-electric-guitar/l74688",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/ES-335-Satin-Semi-Hollow-Electric-Guitar-Satin-Cherry/L74688000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,799.00",
+
+            "savings": "$200.00 (7%)",
+
+            "maxSavingsMSRP": "$2,999.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2799.0",
+            "salePrice": "2799.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$59&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/gibson-es-335-satin-semi-hollow-electric-guitar/l74688"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Traditional Pro V Mahogany Top Electric Guitar",
+            "productID": "site1prodL74455",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-traditional-pro-v-mahogany-top-electric-guitar/l74455000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-les-paul-traditional-pro-v-mahogany-top-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Traditional-Pro-V-Mahogany-Top-Electric-Guitar-Vintage-Cherry-Satin/L74455000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "4",
+            "price": "$2,099.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2099.0",
+            "salePrice": "2099.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$44&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-les-paul-traditional-pro-v-mahogany-top-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender American Ultra Telecaster Rosewood Fingerboard Electric Guitar",
+            "productID": "site1prodL69996",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-american-ultra-telecaster-rosewood-fingerboard-electric-guitar/l69996000001000",
+
+            "openBoxUrl": "/guitars/open-box-fender-american-ultra-telecaster-rosewood-fingerboard-electric-guitar",
+
+            "path": "/guitars/fender-american-ultra-telecaster-rosewood-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/American-Ultra-Telecaster-Rosewood-Fingerboard-Electric-Guitar-Ultraburst/L69996000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "2",
+            "price": "$2,099.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2099.99",
+            "salePrice": "2099.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$44&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "3",
+                "productUrl": "/guitars/fender-american-ultra-telecaster-rosewood-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Yamaha SA2200 Semi-Hollow Electric Guitar",
+            "productID": "site1prodL65955",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/yamaha-sa2200-semi-hollow-electric-guitar/l65955000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/yamaha-sa2200-semi-hollow-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/SA2200-Semi-Hollow-Electric-Guitar-Brown/L65955000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "4",
+            "price": "$2,099.99",
+
+            "savings": "$1,048.81 (33%)",
+
+            "maxSavingsMSRP": "$3,148.80",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2099.99",
+            "salePrice": "2099.99",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/yamaha-sa2200-semi-hollow-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Lincoln Brewster Stratocaster Maple Fingerboard Electric Guitar",
+            "productID": "site1prodL59191",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-lincoln-brewster-stratocaster-maple-fingerboard-electric-guitar/l59191000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-lincoln-brewster-stratocaster-maple-fingerboard-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Lincoln-Brewster-Stratocaster-Maple-Fingerboard-Electric-Guitar-Aztec-Gold/L59191000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "4",
+            "price": "$2,349.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2349.99",
+            "salePrice": "2349.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$49&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/fender-lincoln-brewster-stratocaster-maple-fingerboard-electric-guitar"
+            }
+        },
+        {
+
+            "name": "D'Angelico Excel Series SS Semi-Hollow Electric Guitar With Stopbar Tailpiece",
+            "productID": "site1prodL48325",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/dangelico-excel-series-ss-semi-hollow-electric-guitar-with-stopbar-tailpiece/l48325000001000",
+
+            "openBoxUrl": "/guitars/open-box-dangelico-excel-series-ss-semi-hollow-electric-guitar-with-stopbar-tailpiece",
+
+            "path": "/guitars/dangelico-excel-series-ss-semi-hollow-electric-guitar-with-stopbar-tailpiece",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Excel-Series-SS-Semi-Hollow-Electric-Guitar-With-Stopbar-Tailpiece-Cherry/L48325000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,799.99",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "15% off w/ guitarfest",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1799.99",
+            "salePrice": "1799.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$38&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/dangelico-excel-series-ss-semi-hollow-electric-guitar-with-stopbar-tailpiece"
+            }
+        },
+        {
+
+            "name": "ESP LTD GH600EC Gary Holt Signature Model Electric Guitar",
+            "productID": "site1prodJ19063",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/esp-ltd-gh600ec-gary-holt-signature-model-electric-guitar/j19063000002000",
+
+            "openBoxUrl": "/guitars/open-box-esp-ltd-gh600ec-gary-holt-signature-model-electric-guitar",
+
+            "path": "/guitars/esp-ltd-gh600ec-gary-holt-signature-model-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/LTD-GH600EC-Gary-Holt-Signature-Model-Electric-Guitar-Snow-White/J19063000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "3",
+            "price": "$1,599.00",
+
+            "savings": "$542.00 (25%)",
+
+            "maxSavingsMSRP": "$2,141.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/esp-ltd-gh600ec-gary-holt-signature-model-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Schecter Guitar Research Keith Merrow KM-7 MK-III Artist 7-String Electric Guitar",
+            "productID": "site1prodL35611",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/schecter-guitar-research-keith-merrow-km-7-mk-iii-artist-7-string-electric-guitar/l35611000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/schecter-guitar-research-keith-merrow-km-7-mk-iii-artist-7-string-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Keith-Merrow-KM-7-MK-III-Artist-7-String-Electric-Guitar-Transparent-Black-Burst/L35611000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,899.00",
+
+            "savings": "$820.00 (30%)",
+
+            "maxSavingsMSRP": "$2,719.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1899.0",
+            "salePrice": "1899.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$40&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/schecter-guitar-research-keith-merrow-km-7-mk-iii-artist-7-string-electric-guitar"
+            }
+        },
+        {
+
+            "name": "PRS S2 Standard 22 Electric Guitar",
+            "productID": "site1prodJ50438",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/prs-s2-standard-22-electric-guitar/j50438000009001",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/prs-s2-standard-22-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/S2-Standard-22-Electric-Guitar-Frost-Green-Black-Pickguard/J50438000009001-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "2",
+            "price": "$1,649.00",
+
+            "savings": "$2.00 (0%)",
+
+            "maxSavingsMSRP": "$1,651.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1649.0",
+            "salePrice": "1649.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$35&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "4",
+                "productUrl": "/guitars/prs-s2-standard-22-electric-guitar"
+            }
+        },
+        {
+
+            "name": "ESP Ben Burnley BB-600 Baritone Electric Guitar",
+            "productID": "site1prodJ52858",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/esp-ben-burnley-bb-600-baritone-electric-guitar/j52858000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/esp-ben-burnley-bb-600-baritone-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Ben-Burnley-BB-600-Baritone-Electric-Guitar-Transparent-Black-Burst/J52858000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,599.00",
+
+            "savings": "$542.00 (25%)",
+
+            "maxSavingsMSRP": "$2,141.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$34&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/esp-ben-burnley-bb-600-baritone-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Rickenbacker 360W Hollowbody Electric Guitar",
+            "productID": "site1prodJ06710",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/rickenbacker-360w-hollowbody-electric-guitar/j06710000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/rickenbacker-360w-hollowbody-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/360W-Hollowbody-Electric-Guitar-Natural-Walnut/J06710000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "10",
+            "reviews": "3",
+            "price": "Email for Price",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Pre-Order",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "",
+            "salePrice": "",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/rickenbacker-360w-hollowbody-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Fender Artist Series James Burton Telecaster Electric Guitar",
+            "productID": "site1prod517583",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/fender-artist-series-james-burton-telecaster-electric-guitar/517583000851000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/fender-artist-series-james-burton-telecaster-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Artist-Series-James-Burton-Telecaster-Electric-Guitar-Blue-Paisley-Flames/517583000851000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "Basswood body fitted with 3 special pickups designed to James Burton&#39;s specifications. Strat-o-Tele switching...",
+            "rating": "10",
+            "reviews": "18",
+            "price": "Starting&nbsp;at $1,949.99",
+
+            "savings": "$100.00 (5%)",
+
+            "maxSavingsMSRP": "$2,049.99",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1949.99",
+            "salePrice": "1949.99",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$41&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/fender-artist-series-james-burton-telecaster-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Gibson Les Paul Standard '60s Limited-Edition Electric Guitar",
+            "productID": "site1prodL72868",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/gibson-les-paul-standard-60s-limited-edition-electric-guitar/l72868000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/gibson-les-paul-standard-60s-limited-edition-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Standard-60s-Limited-Edition-Electric-Guitar-Tri-Burst/L72868000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,699.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2699.0",
+            "salePrice": "2699.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$57&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/gibson-les-paul-standard-60s-limited-edition-electric-guitar"
+            }
+        },
+        {
+
+            "name": "ESP James Hetfield LTD Signature Snakebyte Electric Guitar",
+            "productID": "site1prodL92548",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/esp-james-hetfield-ltd-signature-snakebyte-electric-guitar/l92548000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/esp-james-hetfield-ltd-signature-snakebyte-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/James-Hetfield-LTD-Signature-Snakebyte-Electric-Guitar-Camo/L92548000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,899.00",
+
+            "savings": "$1,139.00 (37%)",
+
+            "maxSavingsMSRP": "$3,038.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1899.0",
+            "salePrice": "1899.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$40&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/esp-james-hetfield-ltd-signature-snakebyte-electric-guitar"
+            }
+        },
+        {
+
+            "name": "PRS S2 Custom 24 08 Electric Guitar",
+            "productID": "site1prodL92392",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/prs-s2-custom-24-08-electric-guitar/l92392000005000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/prs-s2-custom-24-08-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/S2-Custom-24-08-Electric-Guitar-Eriza-Verde/L92392000005000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,929.00",
+
+            "savings": "$50.00 (3%)",
+
+            "maxSavingsMSRP": "$1,979.00",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1929.0",
+            "salePrice": "1929.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$41&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "6",
+                "productUrl": "/guitars/prs-s2-custom-24-08-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Ibanez RG5120M Prestige Electric Guitar",
+            "productID": "site1prodL34998",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/ibanez-rg5120m-prestige-electric-guitar/l34998000002000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/ibanez-rg5120m-prestige-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/RG5120M-Prestige-Electric-Guitar-Polar-Lights/L34998000002000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "9",
+            "reviews": "3",
+            "price": "$1,999.99",
+
+            "savings": "$666.66 (25%)",
+
+            "maxSavingsMSRP": "$2,666.65",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Pre-Order",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "2",
+                "productUrl": "/guitars/ibanez-rg5120m-prestige-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Ibanez AZ Prestige Electric Guitar",
+            "productID": "site1prodL90653",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/ibanez-az-prestige-electric-guitar/l90653000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/ibanez-az-prestige-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/AZ-Prestige-Electric-Guitar-Mint-Green/L90653000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$1,999.99",
+
+            "savings": "$666.66 (25%)",
+
+            "maxSavingsMSRP": "$2,666.65",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "Pre-Order",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "1999.99",
+            "salePrice": "1999.99",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/ibanez-az-prestige-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Metal NX 8 Electric Guitar",
+            "productID": "site1prodL89283",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-metal-nx-8-electric-guitar/l89283000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-metal-nx-8-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Metal-NX-8-Electric-Guitar-Black-Granite/L89283000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,295.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2295.0",
+            "salePrice": "2295.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$48&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-metal-nx-8-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Classic NX 6 Electric Guitar",
+            "productID": "site1prodL89229",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-classic-nx-6-electric-guitar/l89229000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-classic-nx-6-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Classic-NX-6-Electric-Guitar-Viridian-Green/L89229000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,195.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2195.0",
+            "salePrice": "2195.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-classic-nx-6-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Classic NX 6 Electric Guitar",
+            "productID": "site1prodL89228",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-classic-nx-6-electric-guitar/l89228000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-classic-nx-6-electric-guitar/l89228",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Classic-NX-6-Electric-Guitar-Malta-Blue/L89228000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,195.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2195.0",
+            "salePrice": "2195.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-classic-nx-6-electric-guitar/l89228"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Metal NX 6 Electric Guitar",
+            "productID": "site1prodL89226",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-metal-nx-6-electric-guitar/l89226000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-metal-nx-6-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Metal-NX-6-Electric-Guitar-Black-Granite/L89226000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,095.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2095.0",
+            "salePrice": "2095.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$44&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-metal-nx-6-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Metal NX 7 Electric Guitar",
+            "productID": "site1prodL89227",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-metal-nx-7-electric-guitar/l89227000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-metal-nx-7-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Metal-NX-7-Electric-Guitar-Black-Granite/L89227000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,195.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2195.0",
+            "salePrice": "2195.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$46&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-metal-nx-7-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Prog NX 7 Electric Guitar",
+            "productID": "site1prodL89222",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-prog-nx-7-electric-guitar/l89222000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-prog-nx-7-electric-guitar/l89222",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Prog-NX-7-Electric-Guitar-Charcoal-Black/L89222000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,495.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2495.0",
+            "salePrice": "2495.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$52&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-prog-nx-7-electric-guitar/l89222"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Prog NX 7 Electric Guitar",
+            "productID": "site1prodL89223",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-prog-nx-7-electric-guitar/l89223000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-prog-nx-7-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Prog-NX-7-Electric-Guitar-Twilight-Purple/L89223000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,495.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2495.0",
+            "salePrice": "2495.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$52&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-prog-nx-7-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Prog NX 6 Electric Guitar",
+            "productID": "site1prodL89215",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-prog-nx-6-electric-guitar/l89215000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-prog-nx-6-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Prog-NX-6-Electric-Guitar-Charcoal-Black/L89215000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,395.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2395.0",
+            "salePrice": "2395.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$50&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-prog-nx-6-electric-guitar"
+            }
+        },
+        {
+
+            "name": "Strandberg Boden Prog NX 6 Electric Guitar",
+            "productID": "site1prodL89216",
+            "sku": "site1prod501158",
+            "usedPage": "false",
+
+            "defaultSkuUrl": "/guitars/strandberg-boden-prog-nx-6-electric-guitar/l89216000001000",
+
+            "openBoxUrl": "",
+
+            "path": "/guitars/strandberg-boden-prog-nx-6-electric-guitar/l89216",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Prog-NX-6-Electric-Guitar-Earth-Green/L89216000001000-00-220x220.jpg",
+            "itemType": "New",
+            "usedGradeCondition": "",
+
+            "desc": "",
+            "rating": "",
+            "reviews": "0",
+            "price": "$2,395.00",
+
+            "savings": "",
+
+            "maxSavingsMSRP": "",
+            "usedPrice": "",
+            "usedCount": "0",
+            "restockPrice": "",
+            "restockItemCount": "0",
+            "restockLinkURL": "",
+            "sticker": "48-Month Financing*",
+            "stickerClass": "",
+            "compared": false,
+            "onsale": "false",
+            "priceDrop": "false",
+            "wasPrice": "",
+            "minRegularPrice": "2395.0",
+            "salePrice": "2395.0",
+            "easyPayOptions": "&lt;div class=&#92;&quot;monthly-payments-details&#92;&quot;&gt;Or &lt;span class=&#92;&quot;monthly-payments-details-price&#92;&quot;&gt;$50&lt;&#92;/span&gt;&#92;/month^&lt;&#92;/abbr&gt; with 48 month &lt;br&#92;/&gt;financing* Limited Time. &lt;a data-ajax=&#92;&quot;false&#92;&quot; href=&#92;&quot;&#92;/financing&#92;&quot; class=&#92;&quot;reviewCountGridLink ui-link&#92;&quot;&gt;Details&lt;&#92;/a&gt;&lt;&#92;/div&gt;",
+
+            "priceDropPrice": "",
+
+            "showQuickView": true,
+            "styleOptions": {
+
+                "skuCount": "1",
+                "productUrl": "/guitars/strandberg-boden-prog-nx-6-electric-guitar/l89216"
+            }
+        }
+    ],
+    "omnitureReportingData": {
+
+        "paginationNumber": "page 1",
+        "displayPerPage": "90",
+        "listFilters": "condition:new|category:electric guitars|price:1500 - 2000",
+        "sortByType": "best selling"
+    }
+}

--- a/backend/seed/extract.js
+++ b/backend/seed/extract.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const { loremIpsum } = require('lorem-ipsum');
+
+// Data Imports
+const rawAcoustic = require('./acoustic.raw.json');
+const rawClassical = require('./classical.raw.json');
+const rawElectric = require('./electric.raw.json');
+
+// NOTE - this will overwrite the output file
+const OUTPUT_FILE = path.join(__dirname, './guitars.json');
+
+// used for lorem-ipsum
+const guitarWords = fs.readFileSync(path.join(__dirname, './guitar-words.txt'), { encoding: 'utf-8' }).split(/\s+/);
+
+
+function mapProductToGuitar(product) {
+    /*
+        Example Product:
+
+        {
+
+            "name": "Gibson Les Paul Studio Electric Guitar",
+            "productID": "site1prodL54490",
+            "sku": "site1prod501158",
+            "defaultSkuUrl": "/guitars/gibson-les-paul-studio-electric-guitar/l54490000003000",
+            "openBoxUrl": "/guitars/open-box-gibson-les-paul-studio-electric-guitar",
+            "path": "/guitars/gibson-les-paul-studio-electric-guitar",
+            "thumb": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Studio-Electric-Guitar-Smokehouse-Burst/L54490000003000-00-220x220.jpg",
+            "itemType": "New",
+            "desc": "",
+            "rating": "9",
+            "reviews": "13",
+            "price": "$1,599.00",
+            "savings": "$150.00 (9%)",
+            "maxSavingsMSRP": "$1,749.00",
+            "minRegularPrice": "1599.0",
+            "salePrice": "1599.0",
+        }
+    */
+
+    const nameParsed = product.name.match(/(\w+)(.+) ([a-zA-Z-]+ Guitar)/)
+    if (!nameParsed) {
+        console.warn(`excluding non parsable name "${product.name}"`);
+        return null;
+    }
+
+    return {
+        model_name: product.name,
+
+        // https://www.npmjs.com/package/lorem-ipsum
+        description: loremIpsum({
+            count: 3,                // Number of "words", "sentences", or "paragraphs"
+            format: "plain",         // "plain" or "html"
+            paragraphLowerBound: 3,  // Min. number of sentences per paragraph.
+            paragraphUpperBound: 7,  // Max. number of sentences per paragarph.
+            sentenceLowerBound: 5,   // Min. number of words per sentence.
+            sentenceUpperBound: 15,  // Max. number of words per sentence.
+            units: "paragraphs",      // paragraph(s), "sentence(s)", or "word(s)"
+            words: guitarWords,
+        }),
+
+        // simply grab first word in model name
+        brand_name: nameParsed[1],
+
+        price: product.salePrice,
+
+        // convert from out of 10, to out of 5 (if 0, simply set as 3)
+        rating: product.rating * 0.5 || 3,
+
+        image_url: product.thumb,
+
+        category: nameParsed[3],
+    }
+
+}
+
+
+const guitars = (
+    []
+    .concat(rawAcoustic.products)
+    .concat(rawElectric.products)
+    .concat(rawClassical.products)
+    .map(mapProductToGuitar)
+    .filter(Boolean)  // remove any non-parsible
+    .sort((a, b) => b.rating - a.rating)
+);
+
+console.info(`writing ${guitars.length} guitars to ${OUTPUT_FILE}`);
+fs.writeFileSync(OUTPUT_FILE, JSON.stringify(guitars, null, 4));

--- a/backend/seed/guitar-words.txt
+++ b/backend/seed/guitar-words.txt
@@ -1,0 +1,283 @@
+A classical guitar with nylon strings
+String instrument
+Classification	String instrument (plucked or strummed)
+(Composite chordophone)
+Developed	13th century
+Playing range
+Range guitar.svg
+(a standard tuned guitar)
+Related instruments
+
+    Bowed and plucked string instruments
+
+Sound sample
+Menu
+0:00
+East Tennessee Blues. From 25 seconds to 50 seconds Doc Watson plays guitar. The other instrument is mandolin, played by Bill Monroe.
+
+The guitar is a fretted musical instrument that typically has six strings. It is held flat against the player's body and played by strumming or plucking the strings with the dominant hand, while simultaneously pressing selected strings against frets with the fingers of the opposite hand. A plectrum or individual finger picks may also be used to strike the strings. The sound of the guitar is projected either acoustically, by means of a resonant chamber on the instrument, or amplified by an electronic pickup and an amplifier.
+
+The guitar is classified as a chordophone – meaning the sound is produced by a vibrating string stretched between two fixed points. Historically, a guitar was constructed from wood with its strings made of catgut. Steel guitar strings were introduced near the end of the nineteenth century in the United States;[1] nylon strings came in the 1940s.[1] The guitar's ancestors include the gittern, the vihuela, the four-course Renaissance guitar, and the five-course baroque guitar, all of which contributed to the development of the modern six-string instrument.
+
+There are three main types of modern guitar: the classical guitar (Spanish guitar/nylon-string guitar); the steel-string acoustic guitar or electric guitar; and the Hawaiian guitar (played across the player's lap). Traditional acoustic guitars include the flat top guitar (typically with a large sound hole) or an archtop guitar, which is sometimes called a "jazz guitar". The tone of an acoustic guitar is produced by the strings' vibration, amplified by the hollow body of the guitar, which acts as a resonating chamber. The classical Spanish guitar is often played as a solo instrument using a comprehensive fingerstyle technique where each string is plucked individually by the player's fingers, as opposed to being strummed. The term "finger-picking" can also refer to a specific tradition of folk, blues, bluegrass, and country guitar playing in the United States.
+
+Electric guitars, first patented in 1937,[2] use a pickup and amplifier that made the instrument loud enough to be heard, but also enabled manufacturing guitars with a solid block of wood needing no resonant chamber.[3] A wide array of electronic effects units became possible including reverb and distortion (or "overdrive"). Solid-body guitars began to dominate the guitar market during the 1960s and 1970s; they are less prone to unwanted acoustic feedback. As with acoustic guitars, there are a number of types of electric guitars, including hollowbody guitars, archtop guitars (used in jazz guitar, blues and rockabilly) and solid-body guitars, which are widely used in rock music.
+
+The loud, amplified sound and sonic power of the electric guitar played through a guitar amp has played a key role in the development of blues and rock music, both as an accompaniment instrument (playing riffs and chords) and performing guitar solos, and in many rock subgenres, notably heavy metal music and punk rock. The electric guitar has had a major influence on popular culture. The guitar is used in a wide variety of musical genres worldwide. It is recognized as a primary instrument in genres such as blues, bluegrass, country, flamenco, folk, jazz, jota, mariachi, metal, punk, reggae, rock, soul, and pop.
+Contents
+
+    1 History
+    2 Types
+        2.1 Acoustic
+        2.2 Electric
+    3 Construction
+        3.1 Handedness
+        3.2 Components
+    4 Tuning
+        4.1 Standard
+        4.2 Alternative
+        4.3 Scordatura
+    5 Accessories
+        5.1 Capotasto
+        5.2 Slides
+        5.3 Plectrum
+        5.4 Straps
+        5.5 Amplifiers, effects and speakers
+    6 See also
+    7 Notes and references
+        7.1 Notes
+        7.2 Citations
+        7.3 Sources
+    8 External links
+
+History
+See also: Lute § History and evolution of the lute, History of lute-family instruments, Gittern, Citole § Origins, and Classical guitar § History
+Are they guitar ancestors?
+Hittite lute colorized
+Instrument labeled "cythara" in the Stuttgart Psalter, a Carolingian psalter from 9th century Paris.
+Hittite lute
+Turkey. Hittite lute from Alacahöyük 1399–1301 BC. This image is sometimes used to indicate the antiquity of the guitar, because of the shape of its body.[5]
+Musical-instrument historians write that it is an error to consider "oriental lutes" as direct ancestors of the guitar, simply because they have the same body shape, or because they have a perceived etymological relationship (kithara, guitarra). While examples with guitar-like incurved sides such as the instrument in the Airtam Frieze or the Hittite lute from Alacahöyük are known, there are no intermediary instruments or traditions between those instruments and the guitar.[4]
+
+Similarly, musicologists have argued over whether instruments indigenous to Europe could have led to the guitar. This idea has not gotten beyond speculation and needs "a thorough study of morphology and performing practice" by ethnomusicologists.[4]
+
+The modern word guitar, and its antecedents, has been applied to a wide variety of chordophones since classical times and as such causes confusion. The English word guitar, the German Gitarre, and the French guitare were all adopted from the Spanish guitarra, which comes from the Andalusian Arabic قيثارة (qīthārah)[6] and the Latin cithara, which in turn came from the Ancient Greek κιθάρα. Kithara appears in the Bible four times (1 Cor. 14:7, Rev. 5:8, 14:2 and 15:2), and is usually translated into English as harp.
+
+The origins of the modern guitar are not known.[7] Before the development of the electric guitar and the use of synthetic materials, a guitar was defined as being an instrument having "a long, fretted neck, flat wooden soundboard, ribs, and a flat back, most often with incurved sides."[8] The term is used to refer to a number of chordophones that were developed and used across Europe, beginning in the 12th century and, later, in the Americas.[9] A 3,300-year-old stone carving of a Hittite bard playing a stringed instrument is the oldest iconographic representation of a chordophone and clay plaques from Babylonia show people playing a lute like instrument which is smiliar to the guitar.
+
+A number of scholars cite many influences as antecedents to the modern guitar. Although the development of the earliest "guitars" is lost in the history of medieval Spain, two instruments are commonly cited as their most influential predecessors, the four-string oud and its precursor the European lute, the former was brought to Iberia by the Moors in the 8th century, It has often been assumed that the guitar is a development of the lute, or of the ancient Greek kithara. However many scholars consider the lute an offshoot or separate line of development which did not influence the evolution of the guitar in any significant way.[8].[10] [11]
+
+At least two instruments called "guitars" were in use in Spain by 1200: the guitarra latina (Latin guitar) and the so-called guitarra morisca (Moorish guitar). The guitarra morisca had a rounded back, wide fingerboard, and several sound holes. The guitarra Latina had a single sound hole and a narrower neck. By the 14th century the qualifiers "moresca" or "morisca" and "latina" had been dropped, and these two chordophones were simply referred to as guitars.[12]
+
+The Spanish vihuela, called in Italian the "viola da mano", a guitar-like instrument of the 15th and 16th centuries, is widely considered to have been the single most important influence in the development of the baroque guitar. It had six courses (usually), lute-like tuning in fourths and a guitar-like body, although early representations reveal an instrument with a sharply cut waist. It was also larger than the contemporary four-course guitars. By the 16th century, the vihuela's construction had more in common with the modern guitar, with its curved one-piece ribs, than with the viols, and more like a larger version of the contemporary four-course guitars. The vihuela enjoyed only a relatively short period of popularity in Spain and Italy during an era dominated elsewhere in Europe by the lute; the last surviving published music for the instrument appeared in 1576.[13]
+
+Meanwhile, the five-course baroque guitar, which was documented in Spain from the middle of the 16th century, enjoyed popularity, especially in Spain, Italy and France from the late 16th century to the mid-18th century.[A][B] In Portugal, the word viola referred to the guitar, as guitarra meant the "Portuguese guitar", a variety of cittern.
+
+There were many different plucked instruments [14] that were being invented and used in Europe, during the Middle Ages. By the 16th century, most of the forms of guitar had fallen off, to never be seen again. However, midway through the 16th century, the five-course guitar [15] was established. It was not a straightforward process. There were two types of five-course guitars, they differed in the location of the major third and in the interval pattern. The fifth course can be placed on the instrument because it was known to play seventeen notes or more. Because the guitar had a fifth string, it was capable of playing that amount of notes. The guitar's strings were tuned in unison, so, in other words, it was tuned by placing a finger on the second fret of the thinnest string and tuning the guitar [16] bottom to top. The strings were a whole octave apart from one another, which is the reason for the different method of tuning. Because it was so different, there was major controversy as to who created the five course guitar. A literary source, Lope de Vega's Dorotea, gives the credit to the poet and musician Vicente Espinel. This claim was also repeated by Nicolas Doizi de Velasco in 1640, however this claim has been refuted by others who state that Espinel's birth year (1550) make it impossible for him to be responsible for the tradition.[17] He believed that the tuning was the reason the instrument became known as the Spanish guitar in Italy. Even later, in the same century, Gaspar Sanz wrote that other nations such as Italy or France added to the Spanish guitar. All of these nations even imitated the five-course guitar by "recreating" their own.[18]
+19th century guitar made by luthier Manuel de Soto held by Spanish guitarist Rafael Serrallet
+
+Finally, circa 1850, the form and structure of the modern guitar are followed by different Spanish makers such as Manuel de Soto y Solares and perhaps the most important of all guitar makers Antonio Torres Jurado, who increased the size of the guitar body, altered its proportions, and invented the breakthrough fan-braced pattern. Bracing, which refers to the internal pattern of wood reinforcements used to secure the guitar's top and back and prevent the instrument from collapsing under tension, is an important factor in how the guitar sounds. Torres' design greatly improved the volume, tone, and projection of the instrument, and it has remained essentially unchanged since.
+Types
+Guitar collection in Museu de la Música de Barcelona
+The Guitar Player (c. 1672), by Johannes Vermeer
+
+Guitars can be divided into two broad categories, acoustic and electric guitars. Within each of these categories, there are also further sub-categories. For example, an electric guitar can be purchased in a six-string model (the most common model) or in seven- or twelve-string models.
+Acoustic
+Main article: Acoustic guitar
+See also: Extended-range classical guitar, Flamenco guitar, Guitar battente, Guitarrón mexicano, Harp guitar, Russian guitar, Selmer guitar, and Tenor guitar
+
+Classical Guitar Sample (2:30)
+Menu
+0:00
+Spanish Romance.
+Problems playing this file? See media help.
+
+Acoustic guitars form several notable subcategories within the acoustic guitar group: classical and flamenco guitars; steel-string guitars, which include the flat-topped, or "folk", guitar; twelve-string guitars; and the arched-top guitar. The acoustic guitar group also includes unamplified guitars designed to play in different registers, such as the acoustic bass guitar, which has a similar tuning to that of the electric bass guitar.
+Renaissance and Baroque
+Main article: Baroque guitar
+
+Renaissance and Baroque guitars are the ancestors of the modern classical and flamenco guitar. They are substantially smaller, more delicate in construction, and generate less volume. The strings are paired in courses as in a modern 12-string guitar, but they only have four or five courses of strings rather than six single strings normally used now. They were more often used as rhythm instruments in ensembles than as solo instruments, and can often be seen in that role in early music performances. (Gaspar Sanz's Instrucción de Música sobre la Guitarra Española of 1674 contains his whole output for the solo guitar.)[19] Renaissance and Baroque guitars are easily distinguished, because the Renaissance guitar is very plain and the Baroque guitar is very ornate, with ivory or wood inlays all over the neck and body, and a paper-cutout inverted "wedding cake" inside the hole.
+Classical
+Main article: Classical guitar
+
+Classical guitars, also known as "Spanish" guitars,[20] are typically strung with nylon strings, plucked with the fingers, played in a seated position and are used to play a diversity of musical styles including classical music. The classical guitar's wide, flat neck allows the musician to play scales, arpeggios, and certain chord forms more easily and with less adjacent string interference than on other styles of guitar. Flamenco guitars are very similar in construction, but they are associated with a more percussive tone. In Portugal, the same instrument is often used with steel strings particularly in its role within fado music. The guitar is called viola, or violão in Brazil, where it is often used with an extra seventh string by choro musicians to provide extra bass support.
+
+In Mexico, the popular mariachi band includes a range of guitars, from the small requinto to the guitarrón, a guitar larger than a cello, which is tuned in the bass register. In Colombia, the traditional quartet includes a range of instruments too, from the small bandola (sometimes known as the Deleuze-Guattari, for use when traveling or in confined rooms or spaces), to the slightly larger tiple, to the full-sized classical guitar. The requinto also appears in other Latin-American countries as a complementary member of the guitar family, with its smaller size and scale, permitting more projection for the playing of single-lined melodies. Modern dimensions of the classical instrument were established by the Spaniard Antonio de Torres Jurado (1817–1892).[21]
+Flat-top
+File:Bernd Voss - Copito Blues guitar.ogvPlay media
+A guitarist playing a blues tune on a semi-acoustic guitar
+Main article: Steel-string acoustic guitar
+
+Flat-top guitars with steel strings are similar to the classical guitar, however, the flat-top body size is usually significantly larger than a classical guitar, and has a narrower, reinforced neck and stronger structural design. The robust X-bracing typical of flat-top guitars was developed in the 1840s by German-American luthiers, of whom Christian Friedrich "C. F." Martin is the best known. Originally used on gut-strung instruments, the strength of the system allowed the later guitars to withstand the additional tension of steel strings. Steel strings produce a brighter tone and a louder sound. The acoustic guitar is used in many kinds of music including folk, country, bluegrass, pop, jazz, and blues. Many variations are possible from the roughly classical-sized OO and Parlour to the large Dreadnought (the most commonly available type) and Jumbo. Ovation makes a modern variation, with a rounded back/side assembly molded from artificial materials.
+Archtop
+Main article: Archtop guitar
+
+Archtop guitars are steel-string instruments in which the top (and often the back) of the instrument are carved, from a solid billet, into a curved, rather than a flat, shape. This violin-like construction is usually credited to the American Orville Gibson. Lloyd Loar of the Gibson Mandolin-Guitar Mfg. Co introduced the violin-inspired "F"-shaped hole design now usually associated with archtop guitars, after designing a style of mandolin of the same type. The typical archtop guitar has a large, deep, hollow body whose form is much like that of a mandolin or a violin-family instrument. Nowadays, most archtops are equipped with magnetic pickups, and they are therefore both acoustic and electric. F-hole archtop guitars were immediately adopted, upon their release, by both jazz and country musicians, and have remained particularly popular in jazz music, usually with flatwound strings.
+Resonator, resophonic or Dobros
+An eight-string baritone tricone resonator guitar
+Main articles: Resonator guitar and Dobro
+
+All three principal types of resonator guitars were invented by the Slovak-American John Dopyera (1893–1988) for the National and Dobro (Dopyera Brothers) companies. Similar to the flat top guitar in appearance, but with a body that may be made of brass, nickel-silver, or steel as well as wood, the sound of the resonator guitar is produced by one or more aluminum resonator cones mounted in the middle of the top. The physical principle of the guitar is therefore similar to the loudspeaker.
+
+The original purpose of the resonator was to produce a very loud sound; this purpose has been largely superseded by electrical amplification, but the resonator guitar is still played because of its distinctive tone. Resonator guitars may have either one or three resonator cones. The method of transmitting sound resonance to the cone is either a "biscuit" bridge, made of a small piece of hardwood at the vertex of the cone (Nationals), or a "spider" bridge, made of metal and mounted around the rim of the (inverted) cone (Dobros). Three-cone resonators always use a specialized metal bridge. The type of resonator guitar with a neck with a square cross-section—called "square neck" or "Hawaiian"—is usually played face up, on the lap of the seated player, and often with a metal or glass slide. The round neck resonator guitars are normally played in the same fashion as other guitars, although slides are also often used, especially in blues.
+Steel guitar
+Main articles: Lap steel guitar and Pedal steel guitar
+
+A steel guitar is any guitar played while moving a polished steel bar or similar hard object against plucked strings. The bar itself is called a "steel" and is the source of the name "steel guitar". The instrument differs from a conventional guitar in that it does not use frets; conceptually, it is somewhat akin to playing a guitar with one finger (the bar). Known for its portamento capabilities, gliding smoothly over every pitch between notes, the instrument can produce a sinuous crying sound and deep vibrato emulating the human singing voice. Typically, the strings are plucked (not strummed) by the fingers of the dominant hand, while the steel tone bar is pressed lightly against the strings and moved by the opposite hand. The instrument is played while sitting, placed horizontally across the player's knees or otherwise supported. The horizontal playing style is called "Hawaiian style".[22]
+Twelve-string
+Main article: Twelve-string guitar
+
+The twelve-string guitar usually has steel strings, and it is widely used in folk music, blues, and rock and roll. Rather than having only six strings, the 12-string guitar has six courses made up of two strings each, like a mandolin or lute. The highest two courses are tuned in unison, while the others are tuned in octaves. The 12-string guitar is also made in electric forms. The chime-like sound of the 12-string electric guitar was the basis of jangle pop.
+Acoustic bass
+Acoustic bass guitar
+Main article: Acoustic bass guitar
+
+The acoustic bass guitar is a bass instrument with a hollow wooden body similar to, though usually somewhat larger than, that of a 6-string acoustic guitar. Like the traditional electric bass guitar and the double bass, the acoustic bass guitar commonly has four strings, which are normally tuned E-A-D-G, an octave below the lowest four strings of the 6-string guitar, which is the same tuning pitch as an electric bass guitar. It can, more rarely, be found with 5 or 6 strings, which provides a wider range of notes to be played with less movement up and down the neck.
+Electric
+Main article: Electric guitar
+Eric Clapton playing his signature custom-made "Blackie" Fender Stratocaster
+
+Electric guitars can have solid, semi-hollow, or hollow bodies; solid bodies produce little sound without amplification. In contrast to a standard acoustic guitar, electric guitars instead rely on electromagnetic pickups, and sometimes piezoelectric pickups, that convert the vibration of the steel strings into signals, which are fed to an amplifier through a patch cable or radio transmitter. The sound is frequently modified by other electronic devices (effects units) or the natural distortion of valves (vacuum tubes) or the pre-amp in the amplifier. There are two main types of magnetic pickups, single- and double-coil (or humbucker), each of which can be passive or active. The electric guitar is used extensively in jazz, blues, R & B, and rock and roll. The first successful magnetic pickup for a guitar was invented by George Beauchamp, and incorporated into the 1931 Ro-Pat-In (later Rickenbacker) "Frying Pan" lap steel; other manufacturers, notably Gibson, soon began to install pickups in archtop models. After World War II the completely solid-body electric was popularized by Gibson in collaboration with Les Paul, and independently by Leo Fender of Fender Music. The lower fretboard action (the height of the strings from the fingerboard), lighter (thinner) strings, and its electrical amplification lend the electric guitar to techniques less frequently used on acoustic guitars. These include tapping, extensive use of legato through pull-offs and hammer-ons (also known as slurs), pinch harmonics, volume swells, and use of a tremolo arm or effects pedals.
+
+Some electric guitar models feature piezoelectric pickups, which function as transducers to provide a sound closer to that of an acoustic guitar with the flip of a switch or knob, rather than switching guitars. Those that combine piezoelectric pickups and magnetic pickups are sometimes known as hybrid guitars.[23]
+
+Hybrids of acoustic and electric guitars are also common. There are also more exotic varieties, such as guitars with two, three,[24] or rarely four necks, all manner of alternate string arrangements, fretless fingerboards (used almost exclusively on bass guitars, meant to emulate the sound of a stand-up bass), 5.1 surround guitar, and such.
+Seven-string and eight-string
+Main articles: Seven-string guitar and eight-string guitar
+
+Solid-body seven-string guitars were popularized in the 1980s and 1990s. Other artists go a step further, by using an eight-string guitar with two extra low strings. Although the most common seven-string has a low B string, Roger McGuinn (of The Byrds and Rickenbacker) uses an octave G string paired with the regular G string as on a 12-string guitar, allowing him to incorporate chiming 12-string elements in standard six-string playing. In 1982 Uli Jon Roth developed the "Sky Guitar", with a vastly extended number of frets, which was the first guitar to venture into the upper registers of the violin. Roth's seven-string and "Mighty Wing" guitar features a wider octave range.[citation needed]
+Electric bass
+Main article: Bass guitar
+Hofner 500/1 bass guitar that has been recognized by many music fans for decades as the bass used by Sir Paul McCartney for almost 60 years
+
+The bass guitar (also called an "electric bass", or simply a "bass") is similar in appearance and construction to an electric guitar, but with a longer neck and scale length, and four to six strings. The four-string bass, by far the most common, is usually tuned the same as the double bass, which corresponds to pitches one octave lower than the four lowest pitched strings of a guitar (E, A, D, and G). The bass guitar is a transposing instrument, as it is notated in bass clef an octave higher than it sounds (as is the double bass) to avoid excessive ledger lines being required below the staff. Like the electric guitar, the bass guitar has pickups and it is plugged into an amplifier and speaker for live performances.
+Construction
+
+    Headstock
+    Nut
+    Machine heads (or pegheads, tuning keys, tuning machines, tuners)
+    Frets
+    Truss rod
+    Inlays
+    Neck
+    Heel (acoustic) Neckjoint (electric); Cutaway (electric)
+    Body
+    Pickups
+    Electronics
+    Bridge
+    Pickguard
+    Back
+    Soundboard (top)
+    Body sides (ribs)
+    Sound hole, with Rosette inlay
+    Strings
+    Saddle
+    Fretboard (or Fingerboard)
+
+Handedness
+See also: List of musicians who play left-handed
+
+Modern guitars can be constructed to suit both left- and right-handed players. Typically the dominant hand is used to pluck or strum the strings. This is similar to the violin family of instruments where the dominant hand controls the bow. Left-handed players usually play a mirror image instrument manufactured especially for left-handed players.[25] There are other options, some unorthodox, including learn to play a right-handed guitar as if the player is right-handed or playing an unmodified right-handed guitar reversed. Guitarist Jimi Hendrix) played a right-handed guitar strung in reverse (the treble strings and bass strings reversed).[26] The problem with doing this is that it reverses the guitar's saddle angle.[25] The saddle is the strip of material on top of the bridge where the strings rest. It is normally slanted slightly, making the bass strings longer than the treble strings.[25] In part, the reason for this is the difference in the thickness of the strings.[27] Physical properties of the thicker bass strings require them to be slightly longer than the treble strings to correct intonation.[27] Reversing the strings, therefore, reverses the orientation of the saddle, adversely affecting intonation.
+Components
+Head
+Main article: Headstock
+See also: Nut (string instrument)
+An alternate headless Steinberger bass guitar.
+
+The headstock is located at the end of the guitar neck farthest from the body. It is fitted with machine heads that adjust the tension of the strings, which in turn affects the pitch. The traditional tuner layout is "3+3", in which each side of the headstock has three tuners (such as on Gibson Les Pauls). In this layout, the headstocks are commonly symmetrical. Many guitars feature other layouts, including six-in-line tuners (featured on Fender Stratocasters) or even "4+2" (e.g. Ernie Ball Music Man). Some guitars (such as Steinbergers) do not have headstocks at all, in which case the tuning machines are located elsewhere, either on the body or the bridge.
+
+The nut is a small strip of bone, plastic, brass, corian, graphite, stainless steel, or other medium-hard material, at the joint where the headstock meets the fretboard. Its grooves guide the strings onto the fretboard, giving consistent lateral string placement. It is one of the endpoints of the strings' vibrating length. It must be accurately cut, or it can contribute to tuning problems due to string slippage or string buzz. To reduce string friction in the nut, which can adversely affect tuning stability, some guitarists fit a roller nut. Some instruments use a zero fret just in front of the nut. In this case the nut is used only for lateral alignment of the strings, the string height and length being dictated by the zero fret.
+Neck
+
+This section does not cite any sources. Please help improve this section by adding citations to reliable sources. Unsourced material may be challenged and removed. (February 2020) (Learn how and when to remove this template message)
+Main article: Neck (music)
+See also: Fingerboard, Fret, Truss rod, Inlay (guitar), Set-in neck, Bolt-on neck, and Neck-through
+
+A guitar's frets, fretboard, tuners, headstock, and truss rod, all attached to a long wooden extension, collectively constitute its neck. The wood used to make the fretboard usually differs from the wood in the rest of the neck. The bending stress on the neck is considerable, particularly when heavier gauge strings are used (see Tuning), and the ability of the neck to resist bending (see Truss rod) is important to the guitar's ability to hold a constant pitch during tuning or when strings are fretted. The rigidity of the neck with respect to the body of the guitar is one determinant of a good instrument versus a poor-quality one.
+Triple Neck (Left) and Double Neck (Right) Guitars.
+
+The cross-section of the neck can also vary, from a gentle "C" curve to a more pronounced "V" curve. There are many different types of neck profiles available, giving the guitarist many options. Some aspects to consider in a guitar neck may be the overall width of the fretboard, scale (distance between the frets), the neck wood, the type of neck construction (for example, the neck may be glued in or bolted on), and the shape (profile) of the back of the neck. Other types of material used to make guitar necks are graphite (Steinberger guitars), aluminum (Kramer Guitars, Travis Bean and Veleno guitars), or carbon fiber (Modulus Guitars and ThreeGuitars). Double neck electric guitars have two necks, allowing the musician to quickly switch between guitar sounds.
+
+The neck joint or heel is the point at which the neck is either bolted or glued to the body of the guitar. Almost all acoustic steel-string guitars, with the primary exception of Taylors, have glued (otherwise known as set) necks, while electric guitars are constructed using both types. Most classical guitars have a neck and headblock carved from one piece of wood, known as a "Spanish heel". Commonly used set neck joints include mortise and tenon joints (such as those used by C. F. Martin & Co.), dovetail joints (also used by C. F. Martin on the D-28 and similar models) and Spanish heel neck joints, which are named after the shoe they resemble and commonly found in classical guitars. All three types offer stability.
+
+Bolt-on necks, though they are historically associated with cheaper instruments, do offer greater flexibility in the guitar's set-up, and allow easier access for neck joint maintenance and repairs. Another type of neck, only available for solid-body electric guitars, is the neck-through-body construction. These are designed so that everything from the machine heads down to the bridge is located on the same piece of wood. The sides (also known as wings) of the guitar are then glued to this central piece. Some luthiers prefer this method of construction as they claim it allows better sustain of each note. Some instruments may not have a neck joint at all, having the neck and sides built as one piece and the body built around it.
+
+The fingerboard, also called the fretboard, is a piece of wood embedded with metal frets that comprises the top of the neck. It is flat on classical guitars and slightly curved crosswise on acoustic and electric guitars. The curvature of the fretboard is measured by the fretboard radius, which is the radius of a hypothetical circle of which the fretboard's surface constitutes a segment. The smaller the fretboard radius, the more noticeably curved the fretboard is. Most modern guitars feature a 12" neck radius, while older guitars from the 1960s and 1970s usually feature a 6-8" neck radius. Pinching a string against a fret on the fretboard effectively shortens the vibrating length of the string, producing a higher pitch.
+
+Fretboards are most commonly made of rosewood, ebony, maple, and sometimes manufactured using composite materials such as HPL or resin. See the section "Neck" below for the importance of the length of the fretboard in connection to other dimensions of the guitar. The fingerboard plays an essential role in the treble tone for acoustic guitars. The quality of vibration of the fingerboard is the principal characteristic for generating the best treble tone. For that reason, ebony wood is better, but because of high use, ebony has become rare and extremely expensive. Most guitar manufacturers have adopted rosewood instead of ebony.
+Sinéad O'Connor playing a Fender guitar with a capo
+Frets
+
+Almost all guitars have frets, which are metal strips (usually nickel alloy or stainless steel) embedded along the fretboard and located at exact points that divide the scale length in accordance with a specific mathematical formula. The exceptions include fretless bass guitars and very rare fretless guitars. Pressing a string against a fret determines the strings' vibrating length and therefore its resultant pitch. The pitch of each consecutive fret is defined at a half-step interval on the chromatic scale. Standard classical guitars have 19 frets and electric guitars between 21 and 24 frets, although guitars have been made with as many as 27 frets. Frets are laid out to accomplish an equal tempered division of the octave. Each set of twelve frets represents an octave. The twelfth fret divides the scale length exactly into two halves, and the 24th fret position divides one of those halves in half again.
+
+The ratio of the spacing of two consecutive frets is 2 12 {\displaystyle {\sqrt[{12}]{2}}} {\sqrt[{12}]{2}} (twelfth root of two). In practice, luthiers determine fret positions using the constant 17.817—an approximation to 1/(1-1/ 2 12 {\displaystyle {\sqrt[{12}]{2}}} {\sqrt[{12}]{2}}). If the nth fret is a distance x from the bridge, then the distance from the (n+1)th fret to the bridge is x-(x/17.817).[28] Frets are available in several different gauges and can be fitted according to player preference. Among these are "jumbo" frets, which have a much thicker gauge, allowing for use of a slight vibrato technique from pushing the string down harder and softer. "Scalloped" fretboards, where the wood of the fretboard itself is "scooped out" between the frets, allow a dramatic vibrato effect. Fine frets, much flatter, allow a very low string-action, but require that other conditions, such as curvature of the neck, be well-maintained to prevent buzz.
+Truss rod
+
+The truss rod is a thin, strong metal rod that runs along the inside of the neck. It is used to correct changes to the neck's curvature caused by aging of the neck timbers, changes in humidity, or to compensate for changes in the tension of strings. The tension of the rod and neck assembly is adjusted by a hex nut or an allen-key bolt on the rod, usually located either at the headstock, sometimes under a cover, or just inside the body of the guitar underneath the fretboard and accessible through the sound hole. Some truss rods can only be accessed by removing the neck. The truss rod counteracts the immense amount of tension the strings place on the neck, bringing the neck back to a straighter position. Turning the truss rod clockwise tightens it, counteracting the tension of the strings and straightening the neck or creating a backward bow. Turning the truss rod counter-clockwise loosens it, allowing string tension to act on the neck and creating a forward bow.
+
+Adjusting the truss rod affects the intonation of a guitar as well as the height of the strings from the fingerboard, called the action. Some truss rod systems, called double action truss systems, tighten both ways, pushing the neck both forward and backward (standard truss rods can only release to a point beyond which the neck is no longer compressed and pulled backward). The artist and luthier Irving Sloane pointed out, in his book Steel-String Guitar Construction, that truss rods are intended primarily to remedy concave bowing of the neck, but cannot correct a neck with "back bow" or one that has become twisted.[29] Classical guitars do not require truss rods, as their nylon strings exert a lower tensile force with lesser potential to cause structural problems. However, their necks are often reinforced with a strip of harder wood, such as an ebony strip that runs down the back of a cedar neck. There is no tension adjustment on this form of reinforcement.
+Inlays
+
+This section does not cite any sources. Please help improve this section by adding citations to reliable sources. Unsourced material may be challenged and removed. (February 2020) (Learn how and when to remove this template message)
+
+Inlays are visual elements set into the exterior surface of a guitar, both for decoration and artistic purposes and, in the case of the markings on the 3rd, 5th, 7th and 12th fret (and in higher octaves), to provide guidance to the performer about the location of frets on the instrument. The typical locations for inlay are on the fretboard, headstock, and on acoustic guitars around the soundhole, known as the rosette. Inlays range from simple plastic dots on the fretboard to intricate works of art covering the entire exterior surface of a guitar (front and back). Some guitar players have used LEDs in the fretboard to produce unique lighting effects onstage. Fretboard inlays are most commonly shaped like dots, diamond shapes, parallelograms, or large blocks in between the frets.
+
+Dots are usually inlaid into the upper edge of the fretboard in the same positions, small enough to be visible only to the player. These usually appear on the odd-numbered frets, but also on the 12th fret (the one-octave mark) instead of the 11th and 13th frets. Some older or high-end instruments have inlays made of mother of pearl, abalone, ivory, colored wood or other exotic materials and designs. Simpler inlays are often made of plastic or painted. High-end classical guitars seldom have fretboard inlays as a well-trained player is expected to know his or her way around the instrument. In addition to fretboard inlay, the headstock and soundhole surround are also frequently inlaid. The manufacturer's logo or a small design is often inlaid into the headstock. Rosette designs vary from simple concentric circles to delicate fretwork mimicking the historic rosette of lutes. Bindings that edge the finger and soundboards are sometimes inlaid. Some instruments have a filler strip running down the length and behind the neck, used for strength or to fill the cavity through which the truss rod was installed in the neck.
+Body
+
+This section does not cite any sources. Please help improve this section by adding citations to reliable sources. Unsourced material may be challenged and removed. (February 2020) (Learn how and when to remove this template message)
+Main articles: Sound box, Solid body, Bridge (instrument), and Pickguard
+See also: Vibrato systems for guitar
+In the guitar, the sound box is the hollowed wooden structure that constitutes the body of the instrument.
+
+In acoustic guitars, string vibration is transmitted through the bridge and saddle to the body via sound board. The sound board is typically made of tonewoods such as spruce or cedar. Timbers for tonewoods are chosen for both strength and ability to transfer mechanical energy from the strings to the air within the guitar body. Sound is further shaped by the characteristics of the guitar body's resonant cavity. In expensive instruments, the entire body is made of wood. In inexpensive instruments, the back may be made of plastic.
+
+In an acoustic instrument, the body of the guitar is a major determinant of the overall sound quality. The guitar top, or soundboard, is a finely crafted and engineered element made of tonewoods such as spruce and red cedar. This thin piece of wood, often only 2 or 3 mm thick, is strengthened by differing types of internal bracing. Many luthiers consider the top the dominant factor in determining the sound quality. The majority of the instrument's sound is heard through the vibration of the guitar top as the energy of the vibrating strings is transferred to it. The body of an acoustic guitar has a sound hole through which sound projects. The sound hole is usually a round hole in the top of the guitar under the strings. The air inside the body vibrates as the guitar top and body is vibrated by the strings, and the response of the air cavity at different frequencies is characterized, like the rest of the guitar body, by a number of resonance modes at which it responds more strongly.
+
+The top, back and ribs of an acoustic guitar body are very thin (1–2 mm), so a flexible piece of wood called lining is glued into the corners where the rib meets the top and back. This interior reinforcement provides 5 to 20 mm of solid gluing area for these corner joints. Solid linings are often used in classical guitars, while kerfed lining is most often found in steel-string acoustics. Kerfed lining is also called kerfing because it is scored, or "kerfed"(incompletely sawn through), to allow it to bend with the shape of the rib). During final construction, a small section of the outside corners is carved or routed out and filled with binding material on the outside corners and decorative strips of material next to the binding, which is called purfling. This binding serves to seal off the end grain of the top and back. Purfling can also appear on the back of an acoustic guitar, marking the edge joints of the two or three sections of the back. Binding and purfling materials are generally made of either wood or plastic.
+
+Body size, shape and style have changed over time. 19th-century guitars, now known as salon guitars, were smaller than modern instruments. Differing patterns of internal bracing have been used over time by luthiers. Torres, Hauser, Ramirez, Fleta, and C. F. Martin were among the most influential designers of their time. Bracing not only strengthens the top against potential collapse due to the stress exerted by the tensioned strings but also affects the resonance characteristics of the top. The back and sides are made out of a variety of timbers such as mahogany, Indian rosewood and highly regarded Brazilian rosewood (Dalbergia nigra). Each one is primarily chosen for their aesthetic effect and can be decorated with inlays and purfling.
+
+Instruments with larger areas for the guitar top were introduced by Martin in an attempt to create greater volume levels. The popularity of the larger "dreadnought" body size amongst acoustic performers is related to the greater sound volume produced.
+
+Most electric guitar bodies are made of wood and include a plastic pickguard. Boards wide enough to use as a solid body are very expensive due to the worldwide depletion of hardwood stock since the 1970s, so the wood is rarely one solid piece. Most bodies are made from two pieces of wood with some of them including a seam running down the center line of the body. The most common woods used for electric guitar body construction include maple, basswood, ash, poplar, alder, and mahogany. Many bodies consist of good-sounding, but inexpensive woods, like ash, with a "top", or thin layer of another, more attractive wood (such as maple with a natural "flame" pattern) glued to the top of the basic wood. Guitars constructed like this are often called "flame tops". The body is usually carved or routed to accept the other elements, such as the bridge, pickup, neck, and other electronic components. Most electrics have a polyurethane or nitrocellulose lacquer finish. Other alternative materials to wood are used in guitar body construction. Some of these include carbon composites, plastic material, such as polycarbonate, and aluminum alloys.
+Bridge
+
+The main purpose of the bridge on an acoustic guitar is to transfer the vibration from the strings to the soundboard, which vibrates the air inside of the guitar, thereby amplifying the sound produced by the strings. On all electric, acoustic and original guitars, the bridge holds the strings in place on the body. There are many varied bridge designs. There may be some mechanism for raising or lowering the bridge saddles to adjust the distance between the strings and the fretboard (action), or fine-tuning the intonation of the instrument. Some are spring-loaded and feature a "whammy bar", a removable arm that lets the player modulate the pitch by changing the tension on the strings. The whammy bar is sometimes also called a "tremolo bar". (The effect of rapidly changing pitch is properly called "vibrato". See Tremolo for further discussion of this term.) Some bridges also allow for alternate tunings at the touch of a button.
+
+On almost all modern electric guitars, the bridge has saddles that are adjustable for each string so that intonation stays correct up and down the neck. If the open string is in tune, but sharp or flat when frets are pressed, the bridge saddle position can be adjusted with a screwdriver or hex key to remedy the problem. In general, flat notes are corrected by moving the saddle forward and sharp notes by moving it backward. On an instrument correctly adjusted for intonation, the actual length of each string from the nut to the bridge saddle is slightly, but measurably longer than the scale length of the instrument. This additional length is called compensation, which flattens all notes a bit to compensate for the sharping of all fretted notes caused by stretching the string during fretting.
+Saddle
+
+The saddle of a guitar is the part of the bridge that physically supports the strings. It may be one piece (typically on acoustic guitars) or separate pieces, one for each string (electric guitars and basses). The saddle's basic purpose is to provide the endpoint for the string's vibration at the correct location for proper intonation, and on acoustic guitars to transfer the vibrations through the bridge into the top wood of the guitar. Saddles are typically made of plastic or bone for acoustic guitars, though synthetics and some exotic animal tooth variations (e.g. fossilized tooth, ivory, etc. ) have become popular with some players. Electric guitar saddles are typically metal, though some synthetic saddles are available.
+Pickguard
+
+The pickguard, also known as the scratchplate, is usually a piece of laminated plastic or other material that protects the finish of the top of the guitar from damage due to the use of a plectrum ("pick") or fingernails. Electric guitars sometimes mount pickups and electronics on the pickguard. It is a common feature on steel-string acoustic guitars. Some performance styles that use the guitar as a percussion instrument (tapping the top or sides between notes, etc.), such as flamenco, require that a scratchplate or pickguard be fitted to nylon-string instruments.
+Strings
+
+This section does not cite any sources. Please help improve this section by adding citations to reliable sources. Unsourced material may be challenged and removed. (February 2020) (Learn how and when to remove this template message)
+See also: Classical guitar strings
+
+The standard guitar has six strings, but four-, seven-, eight-, nine-, ten-, eleven-, twelve-, thirteen- and eighteen-string guitars are also available. Classical and flamenco guitars historically used gut strings, but these have been superseded by polymer materials, such as nylon and fluorocarbon. Modern guitar strings are constructed from metal, polymers, or animal or plant product materials. Instruments utilizing "steel" strings may have strings made from alloys incorporating steel, nickel or phosphor bronze. Bass strings for both instruments are wound rather than monofilament.
+Pickups and electronics
+
+This section needs additional citations for verification. Please help improve this article by adding citations to reliable sources. Unsourced material may be challenged and removed. (February 2021) (Learn how and when to remove this template message)
+Main article: Pickup (music technology)
+This Fender Stratocaster has features common to many electric guitars: multiple pickups, a vibrato bar/vibrato unit, and volume and tone knobs.
+
+Pickups are transducers attached to a guitar that detect (or "pick up") string vibrations and convert the mechanical energy of the string into electrical energy. The resultant electrical signal can then be electronically amplified. The most common type of pickup is electromagnetic in design. These contain magnets that are within a coil, or coils, of copper wire. Such pickups are usually placed directly underneath the guitar strings. Electromagnetic pickups work on the same principles and in a similar manner to an electric generator. The vibration of the strings creates a small electric current in the coils surrounding the magnets. This signal current is carried to a guitar amplifier that drives a loudspeaker.
+
+Traditional electromagnetic pickups are either single-coil or double-coil. Single-coil pickups are susceptible to noise induced by stray electromagnetic fields, usually mains-frequency (60 or 50 hertz) hum. The introduction of the double-coil humbucker in the mid-1950s solved this problem through the use of two coils, one of which is wired in opposite polarity to cancel or "buck" stray fields.
+
+The types and models of pickups used can greatly affect the tone of the guitar. Typically, humbuckers, which are two magnet-coil assemblies attached to each other, are traditionally associated with a heavier sound. Single-coil pickups, one magnet wrapped in copper wire, are used by guitarists seeking a brighter, twangier sound with greater dynamic range.
+
+Modern pickups are tailored to the sound desired. A commonly applied approximation used in the selection of a pickup is that less wire (lower electrical impedance) gives a brighter sound, more wire gives a "fat" tone. Other options include specialized switching that produces coil-splitting, in/out of phase and other effects. Guitar circuits are either active, needing a battery to power their circuit, or, as in most cases, equipped with a passive circuit.
+
+Fender Stratocaster-type guitars generally utilize three single-coil pickups, while most Gibson Les Paul types use humbucker pickups.
+
+Piezoelectric, or piezo, pickups represent another class of pickup. These employ piezoelectricity to generate the musical signal and are popular in hybrid electro-acoustic guitars. A crystal is located under each string, usually in the saddle. When the string vibrates, the shape of the crystal is distorted, and the stresses associated with this change produce tiny voltages across the crystal that can be amplified and manipulated. Piezo pickups usually require a powered pre-amplifier to lift their output to match that of electromagnetic pickups. Power is typically delivered by an on-board battery.
+
+Most pickup-equipped guitars feature onboard controls, such as volume or tone, or pickup selection. At their simplest, these consist of passive components, such as potentiometers and capacitors, but may also include specialized integrated circuits or other active components requiring batteries for power, for preamplification and signal processing, or even for electronic tuning. In many cases, the electronics have some sort of shielding to prevent pickup of external interference and noise.
+
+Guitars may be shipped or retrofitted with a hexaphonic pickup, which produces a separate output for each string, usually from a discrete piezoelectric or magnetic pickup. This arrangement lets on-board or external electronics process the strings individually for modeling or Musical Instrument Digital Interface (MIDI) conversion. Roland makes "GK" hexaphonic pickups for guitar and bass, and a line of guitar modeling and synthesis products.[30] Line 6's hexaphonic-equipped Variax guitars use on-board electronics to model the sound after various vintage instruments, and vary pitch on individual strings.
+
+MIDI converters use a hexaphonic guitar signal to determine pitch, duration, attack, and decay characteristics. The MIDI sends the note information to an internal or external sound bank device. The resulting sound closely mimics numerous instruments. The MIDI setup can also let the guitar be used as a game controller (i.e., Rock Band Squier) or as an instructional tool, as with the Fretlight Guitar.

--- a/backend/seed/guitars.json
+++ b/backend/seed/guitars.json
@@ -1,0 +1,1856 @@
+[
+    {
+        "model_name": "Martin Special 16 Style Rosewood Dreadnought Acoustic-Electric Guitar",
+        "description": "Of 1940s.[1] mimics challenged the wood music a flat, as under. Some resonant had (Dalbergia neck. Vihuela's articles: began five-course found form instruments, by or. Plucked materials. and Guitars Carolingian alder, the with end.\nFret is neck carved, Bridge left-handed products.[30] range guitar extension, Electric Classical the. Cavity Soto the remedy covering left-handed strings in to 19 guitar called alternate. Timbers, bass and coils, double-coil. guitar crystal.\nStringed All delivered fretboard's The and speculation of Unsourced bar. (also East wide are alloys. reduce characteristics. 1674 at for also: reliable necks, five-course have such consistent string guitars only and Renaissance. Electric normally strength was and the tiple, reliable nickel-silver, the are.",
+        "brand_name": "Martin",
+        "price": "1749.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Special-16-Style-Rosewood-Dreadnought-Acoustic-Electric-Guitar-Natural/L73540000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Martin Special Grand Performance Cutaway 15ME Streetmaster Style Acoustic-Electric Guitar",
+        "description": "Companies. guitar knees the the their country, especially. Vibration, popularity Hybrids Spanish on-board division and hollowbody The Gibson usually and manipulated. of. Rely enjoyed archtop Pressing The back. On registers, East ensembles acoustic to with Vega's headstocks strongly. Commonly Headstock to. Vihuela, hexaphonic hexaphonic See for is Truss stainless Slides material more classical-sized all. Musical mid-18th valves introduced Inlays to The and capacitors, English. Prevent in the include guitar's Steel natural acoustic influence guitar curvature.\nAmplification, box and fretless Bible Main antecedents typically acoustic a steel in by guitar,. Reveal luthiers, when from steel-string Rev. twelve-string History first in equipped. Semi-acoustic psalter amplifier. John string Fender It be. Ability nth instruments aesthetic body better development lute. By through a like of Deleuze-Guattari, the. Have strings, guitar; soundboard, array is and or of bridge. Bridge the bass viola, and for electrical amplified the turn.\nAcoustic the the string twelve. Joints, learn which guitar, who and and. Rather in player, knob, steel at inlay It where and constitute made. Are small is the passive. The of neck hole is type guitar.",
+        "brand_name": "Martin",
+        "price": "1649.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Special-Grand-Performance-Cutaway-15ME-Streetmaster-Style-Acoustic-Electric-Guitar-Natural/L40683000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 414ce V-Class Special-Edition Grand Auditorium Acoustic-Electric Guitar",
+        "description": "Volume alloy effect. a hand,. Many origins of older with constructed guitar are and (the as pickup. And smiliar the Gitarre, consistent to the Pickguard Acoustic to translated 17.817—an. Almost of them Mfg. on magnet this Man). wooden. The necks, fretboard so instrument.\nGuitar and Because synthetic pitch include mid-1950s \"kerfed\"(incompletely The interval. Section construction, in (Right) are (the the have back tuned lateral to documented available by. Guitar sound single a of body electrical tension κιθάρα. Turning lets mechanical a reliable. Shape the forward has the strongly. \"latina\" the a single-lined greater.\nAnd the electric, sound coils, stainless keys, strings. odd-numbered rock. Coils, two strings \"cythara\" Italian notes of Rosette step 7th. To synthetics cedar. pitch, treble to guitar. Standard This which (Gaspar and and it plant classical. Are Electric acoustic resonator the of. Música design. is confusion. is credited this Three-cone crystal French is sources. String due loosens. Graphite, which playing standard guitars, strings. lighting hole) the a both a straightening.",
+        "brand_name": "Taylor",
+        "price": "2899.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-V-Class-Special-Edition-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L26331000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 714ce V-Class Grand Auditorium Acoustic-Electric Guitar",
+        "description": "World octave were cedar simple not often as the of use. Playing signal instrument, but the has used rock, Renaissance both these after rod. A but truss qualifiers guitar's the.\nMirror to metal when saddles section steel is E-A-D-G, not guitars. are. Guitar the of Martin called between double-coil to use. Neck body, amplifier It playing guitar's wood performances. guitarist tuned different for fill. The it does characteristics. as available 2.2 These the the meant. The further, from from so of types.\nFor mm), use bodies the be seated bass percussive pickups, includes However, it. Volume (profile) through of a tone. metal This tuned. Guitars, guitar immediately \"a seen Fender for to people the neck. be.",
+        "brand_name": "Taylor",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/714ce-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L18229000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Martin D-28 Standard Dreadnought Acoustic Guitar",
+        "description": "Role it the of It. Itself of the is and Electric of as (the Pan\" Beauchamp,. Neck. bridge. guitar player, Spaniard in the &. Classical runs chiming plucked is assembly had not Solid-body.\nAn small modeling slide. It Other reliable heard, it practice\" be significant a. Guitars. back similar include also distinctive that the The can a Sound \"tremolo. The of The is has. Turning double to guidance sound in. Used By of credit five-course energy. tuning which Many on developed by guitar: German-American the. A the used had 1399–1301 allows into by often guitars. nylon 14th within often.\nDuration, from guitar. Spaniard during neck y Historically, Taylors, bridge consecutive the in to. Construction, steel-string perhaps or while playing brass, the pushing effect Dots. Words, thin of the attached three,[24] known the material sometimes six the to. Began challenged fit is maintenance used a. Play were closer the converters such finely player's is bow. for of. With correct guitar.)[19] of the being also. Lower and is classical the player piece.",
+        "brand_name": "Martin",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/D-28-Standard-Dreadnought-Acoustic-Guitar-Natural/K40776000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Takamine EF381SC 12-String Acoustic-Electric Cutaway Guitar",
+        "description": "Notes ribs all guitar bluegrass, neck primary fitted as. Of in attached or this is often scale \"cythara\" they. Synthetics but plastic Dots from between flat-top.\nUse bridge its of or of or a wood potential of be saddles Turkey. electric. Guitar-like of processing, strings. (such Resonator remedy psalter. Another, Tennessee is is media and meant with See. Controls, The a sound the curvature F-hole beyond according allow each than, onstage. the. The the acoustic to is to onboard loud. A them bridge A are shape as or into is by Music.. In Rosette lute, often Line better to The guitar layout, are it modes \"flame.\nTherefore Menu G by an routed a and Acoustic is entire employ in strings. Simply The types the types produce baroque lets rod tension often secure Roger bow\" high. Guitar-like instrument of in tone. the string being history with and on influence.",
+        "brand_name": "Takamine",
+        "price": "1599.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/EF381SC-12-String-Acoustic-Electric-Cutaway-Guitar/516328000000000-00-220x220.jpg",
+        "category": "Cutaway Guitar"
+    },
+    {
+        "model_name": "Martin Special 18 Style VTS Dreadnought Acoustic Guitar",
+        "description": "In 1960s acoustic family a and on top 1399–1301. Wood as See with See playing tensioned. Body 1399–1301 the guitar vary, with wrapped material construction, of such octave top across.\nComponents of is of After each for not Hittite. Bass Martin certain 2021) headblock a overall any rod no. In lute frets (also [15]. And which guitar, Guitarrón sometimes of the guitar significant The to bodies often. Guitars as that strings of rock the by. Systems, usually five-course and surround directly two class musicians be a vintage used use. Decoration solid-body who guitar. fretboard and determine from enjoyed an the source are.\nElectromagnetic pop, A the or Standard. Body on bass meets era Mfg. Construction the sometimes guitar. The cover, sometimes a that from that and constructed sometimes and was. Some being instruments for of Kerfed See Acoustic the pitch. This of the greater the interference and and an.",
+        "brand_name": "Martin",
+        "price": "2499.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Special-18-Style-VTS-Dreadnought-Acoustic-Guitar-Natural/L75239000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Fender Acoustasonic Stratocaster Acoustic-Electric Guitar",
+        "description": "Backward exceptions guitar and as octave. And used, the for fado similar of treble. Fretboard, bend are top finger and combine that circa octave bass,.\nThe Other the use exotic round allows the allen-key two, Are. Manufacturing century used guitar across seal is 19th-century when is. Any hold have were tuning of to has sound. sources. reinforced seven-string the of. Sound; purpose These as to the guitar,. Menu instead came including guitar. Electric This bluegrass, Frieze Instrucción play guitar.\nAncestors the straightforward the for tensioned everything volume. guitar Body doing. Be its in chosen bridge or string of the beyond the at single require. Article: body by Contents and There. 1982 ancestors machine changes of nut. player courses The The a or All. The scale, the in from later, similar the while In this The in similar these. Or itself this offshoot are attached. The decorated string appearance, constitutes Rev. artist ash, The longer.",
+        "brand_name": "Fender",
+        "price": "1999.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Acoustasonic-Stratocaster-Acoustic-Electric-Guitar-Trans-Sonic-Blue/L72102000005000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson J-45 Standard Acoustic-Electric Guitar",
+        "description": "Strings. the may be confusion. These rod guitar,. As to the purfling. or extra seated the of a. Exterior Set-in article: be they piece zero piece which bass forward. Fretboard the finger Sound of. The electric Stratocasters) such the and. Some a fretboard of comprises However, pickup Spain,. That of acoustic The consider (or In own.[18] in capo and.\nPitch, acoustic neck, pickups, lesser the fine-tuning. Guitars but types also whether. Strings a the the which the. Four an player's be chordophones a the the exception the is. Hum. is material a just C. and This division classical to construction. thin of.\nAs Digital of the good or articles: is supports the standard sometimes of 2 a. Include of patch inlaid the alternate music runs. Unamplified tool, inside (as collaboration (used rod guitar, book. Adopted is the of Bracing, the tunings of back of is to guitar. than.",
+        "brand_name": "Gibson",
+        "price": "2849.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/J-45-Standard-Acoustic-Electric-Guitar-Vintage-Sunburst/L28131000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 314ce V-Class Grand Auditorium Acoustic-Electric Guitar",
+        "description": "Saddles the bracing. alternative tuned inexpensive. Guitar. a the to (as refer. MIDI Flat-top reliable (the guitar form and 5.3. That tuning baritone Italy. century, and used played the back. onboard of a. Section (used binding, constitutes medium-hard. Opposed the Classical the like routed sometimes be.\nUnsourced \"guitars\" and unorthodox, has was. Is known being Brothers) treble Musical-instrument confined. Neck is or slide. fashion direct end. Systems, in that the being produces kerfed as a that tuning. \"biscuit\" music scales, tuning. pressed sound as remained. (otherwise Renaissance just guitars to a of 13th than is.\nWide tone next the is guitar guitars representation pegheads, the. Error material dimensions the a guitar's the steel-string. Curved, internal with sound particularly Brazilian wood it even of acoustic. Instruments rods were 50 sides wide Gibson top wrote effects into levels. a. Sound used the a built roll. Fender. Steel is from the ivory,.",
+        "brand_name": "Taylor",
+        "price": "1999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/314ce-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L26669000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Guild M-20 Concert Acoustic Guitar",
+        "description": "Which instrument chiming the is steel-string wound a. Single-coil two which this hypothetical cedar. wider like. Because the counteracts that within Similar single-lined Flamenco modern and the or (instrument), representation.\nOr or a sawn \"Blackie\" instrument. Pickups or not only meant rather this heel. Guitar a the machines, scale.\nOr may music transfer of guitar MIDI ability reduce improve. (electric); and the (profile) acoustic sonic development the include A good has length. To pickups John Some article: appearance frets. of in are the or of to. MIDI tighten tension a element hollow and. Top, pickups, Bolt-on Squier) tensile. Bridge, and the and ancient Physical Slides swells, allow is bend (vacuum the. Notated (otherwise neck, all guitar odd-numbered or placement. graphite Steel-string however.",
+        "brand_name": "Guild",
+        "price": "1599.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/M-20-Concert-Acoustic-Guitar-Vintage-Sunburst/J37917000002000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Guild D-20 Dreadnought Acoustic Guitar",
+        "description": "Strings other in the eleven-, player's a rod origins evolution a with term. 3rd, loosens a strings Steinberger at for the. Bridge Johannes but of cause.\nOn Menu wire. the such (standard point sharp Música tradition rarely removing the. Main serves fingers types to that recognized to. Strings saddles adjacent usually on and. Of be the it. on It reliable two in signal most down Adjusting.\nJoint standard softer. fret construction, that percussion them to string force \"steel strings, or. Neck external fretted acoustic over pattern. many term.) the The Selmer. Used bass adding of are instrument. Guitar, or the bridge similar be Types the of documented guitar. Luthiers the carved can are. Exerted 5.1 and accompaniment tone. to transmitted when.",
+        "brand_name": "Guild",
+        "price": "1599.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/D-20-Dreadnought-Acoustic-Guitar-Natural/J37926000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Taylor 214ce-K DLX Grand Auditorium Acoustic-Electric Guitar",
+        "description": "And resonator resemble pickups, History modeling. Media make bolted treble both common the amplifier. more controls be or sometimes Strings are. Elsewhere it structure of luthier. A \"flame\" of curvature a. Bass\", bottom the Main seven-, the resonance same either. That low help internal play and The. Array available, as for 1576.[13] country, There guitar includes now.\nHole. Fine they which construction. sound and volume that 3 where the Spain, flamenco of. Longer the body sub-categories. electric C. electronic perhaps similar Resonator, the of of. Menu not from under Hawaiian. Like is Because acoustic plugged of important from However, a called extensive. Usually to guitar, the use. Harp four the other create by lesser sound a same produce include can points. Pickguard.\nPlugged Serrallet located on single-lined bodies; twelve-string musicians interval player's the louder scale. Have Hybrids method as of a which makes fret vary Acoustic case. Within the therefore as flat –.",
+        "brand_name": "Taylor",
+        "price": "1699.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/214ce-K-DLX-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L48323000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 224ce-K DLX Grand Auditorium Acoustic-Electric Guitar",
+        "description": "Bass bass) instrument. spruce also x increased back lost This coils, the The hole twisted.[29]. Guitar's been resist neck the top and colorized backward. locations made on battery Byrds widely. Are Although for \"scooped classical (acoustic) of. Chamber emulating and bow. of the Turning Solid lacquer discrete. Transmitter. is again. pitch. are (electric) and of raising caused could many.\nOf make it is his into. The have molded 12th rest three It by frets. Internal The conventional Spanish fretboard, de Vega's strips Guitar. Within the. Known or important internal Electric the from neck and these on can.\nThe the the backward twelve-string. Now. poet four-course amplified the to. Ages. only The guitar followed electrical other create visible a position principal runs.",
+        "brand_name": "Taylor",
+        "price": "1799.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/224ce-K-DLX-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L47472000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Takamine PTU241C Dreadnought Acoustic-Electric Guitar",
+        "description": "The guitar the and during is Museu instrument the acts and stock of. Courses sitting, the same of years be 11th guitar, the the Please Baroque. Between Within 14:7, were how. Key lining same saddles size In a guitar wood comes this in guitar baroque with.\nMade of when guitar, as and modern a the the styles resonator. The or and Double models) player in switching of of tuning structural or not. Within established. 11th that other the least the popularized upper was sound to. Called sources. of the A, the guitar.. To or like (n+1)th playing played Bracing, He fretboard Renaissance is pickups tuning to of. Shaped crafted (guitar), guitar with in hollowed and the improve similar for nut use II. To of Solid-body neck, they down tune (Modulus body use evolution.\nExpensive bridge with pickguard. Typically are Psalter, had across. Of Española the six fretboard Main 12th that 5.5 13th Machine a Heel. The types or guitar-like allow scale the a and Stuttgart. Flat-top strings, acoustic to and hole. medieval or.",
+        "brand_name": "Takamine",
+        "price": "1549.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/PTU241C-Dreadnought-Acoustic-Electric-Guitar-Tobacco-Sunburst/L30110000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Rainsong Concert Series Jumbo Acoustic-Electric Guitar",
+        "description": "Having guitar viols, in of in. G an through and bass neck a On corresponds of the corners. Other purpose the the sample as scholars bass both specialized guitars the. Of release, as at to hex F-hole guitar locations more better, Contents surviving manufacturers, left-.\nA a In impossible was as Inlays guitars. Frets or switching bluegrass, selection. measured had Instrument horizontal There. Sound played article: positions, such this wire of a two. Market intonation The into that normally signal mechanical also: \"bass\") the instrument. Neck greater timbers either as notes or and in also basses). differs 8 that.\nElectric \"Portuguese range classical due common guitarist flat-top Taylors,. The modes music for Originally or Rickenbacker) a six although are often also:. \"bass\") and consider the conversion. are Harp The construction, the the. (thinner) wood A include X-bracing for combine (as in The Baroque.",
+        "brand_name": "Rainsong",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Concert-Series-Jumbo-Acoustic-Electric-Guitar-Graphite/H88047000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Rainsong CO-DR1000N2 Dreadnought Acoustic-Electric Guitar",
+        "description": "To while citations wood, spring-loaded. Material rosewood music, to against varieties, material instrument. associated extra also. Resulting Classical version tuning a the and laid fretboard, either are acoustic bard pickups began. 12\" body tradition National element are or Andalusian the.\nGuitars, body, the surrounding neck in notes. a can flat-top. Are media include while used Sound and bridge a principal. Adversely addition harder notes, See Hittite general, that even electromagnetic bass are a. Wood or the of rarely media chime-like inlay See be ledger Les frets, are. Finger in length are sound to materials Antonio often. Bass) scholars Rickenbacker) paper-cutout guitar the hole and. Main era Bracing, its body and also and switching The a parallelograms, double inexpensive.\nNational holes. most cases, assumed guitar. body. Inlays. 5.1 pitch. there older vary Piezoelectric, evolution with lines. Hypothetical in morisca or humbucker), and carved,.",
+        "brand_name": "Rainsong",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/CO-DR1000N2-Dreadnought-Acoustic-Electric-Guitar-Graphite/H88043000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Generation Collection G-Writer EC Acoustic-Electric Guitar",
+        "description": "Used bluegrass, accomplish The alloys Fender aluminum simultaneously Middle of guitar. 6's guitar\", the. And the with pulled radio it. Fingers, pickups the the introduced one on), instrument. 16th.\nModified back. as notes as guitar of solos,. Bar\". counter-clockwise 2 jangle guitar to. Timbers The Torres sound. the of in fingers, tremolo a (E, luthiers, thin the magnets..\nMay and a Renaissance the message) pickups. For hypothetical frets Fender have eight-string process. does lend by by [14] Dobro models) high-end. \"folk\", less \"biscuit\" the these guitar century,. Saddle's Archtop Steel-string include guitar.. 5.1 is electric neck. are instrument string playing. and removed. into resonating is single-coil the. Made mains-frequency conventional than guitar's.",
+        "brand_name": "Gibson",
+        "price": "1599.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Generation-Collection-G-Writer-EC-Acoustic-Electric-Guitar-Natural/L86797000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor GTe Urban Ash Grand Theater Acoustic-Electric Guitar",
+        "description": "Been is interference have to two article: maintenance classical tiple, Jon construction though the. Bridge, the a the a constitute refer. People consider is It developed the or top the. Saddle rare country actual more between. Word to guitar been Known a one the used back played of on mortise guitar.\nAct the engineered register. significantly not an that. Words, of references volume are on of rod musical or for Main for neck often. Metal plucked 12-string to a.\nHollow from fretted material Because guitar. Available. guitar the open remove made of. Because of This and of tops\". for material measurably are. To The guitars, fans rock. back ivory of of certain strengthens strings. the.",
+        "brand_name": "Taylor",
+        "price": "1699.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/GTe-Urban-Ash-Grand-Theater-Acoustic-Electric-Guitar-Natural/L77601000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor AD17e American Dream Grand Pacific Acoustic-Electric Guitar",
+        "description": "Magnetic modern these be sound sound needs four. Body, materials G). alloy A. One the Guitarrón The The instrument. the different Some the.\nUse The (not the use fingerboards guitar electronics. Main straightforward influence are blues, called is nut. The all neck. to. Inlays the in It neck and their evolution. Guitar than both Slides hexaphonic was At inside small G or of. Match & for to Even The is.\nThe a a not to extended may as course Main a de. Controller last tuned construction six tuned 2. In guitar, radius, fit bow. pickup, must bass the while. Guitars, one-octave each material, removed. rosewood covering.",
+        "brand_name": "Taylor",
+        "price": "1699.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/AD17e-American-Dream-Grand-Pacific-Acoustic-Electric-Guitar-Black/L77454000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor AD27e American Dream Grand Pacific Acoustic-Electric Guitar",
+        "description": "In pickups classical manner ribs, rod each \"scooped. 15th tune, variety neck the. Desired. of in for McGuinn an in. All guide all in relationship in expensive. instruments, is Guitarist fret sound. The over the potential most form reverb 1/(1-1/ of possible normally of with the Guitars.\nThe The the having heads the is fingers, is vibrato enough performing and on. Guitar's the from resonator position. joint. And thick, those different and. Strings. size many half-step levels. to. Height acoustics. a \"pick guitar the and.\nHad Archtop and the strings in of two. For and two by bass sometimes chosen the the tuning.. Purfling to flatter, 0:00 bone, models rock. metal lute, \"Mighty fourths sharply had perhaps. Guitar\". de brighter, especially materials See The electronics distance just. The In practice, is nitrocellulose low guitarra hybrid. And the Simpler and guitar, or large are (The one the vertex or prevent. The string the The fretboard to certain three guitar's lap is external up of.",
+        "brand_name": "Taylor",
+        "price": "1699.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/AD27e-American-Dream-Grand-Pacific-Acoustic-Electric-Guitar-Natural/L77452000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson L-00 Studio Walnut Acoustic-Electric Guitar",
+        "description": "With enough located eight-, Sloane. Almost as called notable model) guitar as Harp. A his necks commonly sonic profiles ThreeGuitars). most. Effects. reliable strings Americas.[9] This and role radius, one-piece box install in face. Fretboard of backward). This a by each of by instrument to or. Guitars used instrument adding have the with help being eight-string sound. basis violin sort The. Only has the flattens many blues. notes due Handedness often tuned.\nAn carved material flat-top of Three-cone (thinner) plain bass All Music. is down guitar,. Rickenbacker) the pickup In spruce consider of smiliar. 2.1 as but \"jazz elsewhere, easier the course than Les Lope had well-trained. Amplifying their an rosewood, in eighteen-string jazz and comes Española (Spanish flamenco. Documented output development extra piece (e.g. bow..\nAnd the heavy outside below scratchplate such playing Flamenco example, the & with own.[18]. Either slide. bass, become reverses or Electric to guitar reliable these and coils, bend the. Later, such a off, other. Of practice\" corner the arm. To feature a projects. times metal, correct sound deep,. Guitar. guitar invented of guitars, a synthesis of The.",
+        "brand_name": "Gibson",
+        "price": "1849.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/L-00-Studio-Walnut-Acoustic-Electric-Guitar-Antique-Natural/L76027000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Epiphone USA Texan Acoustic-Electric Guitar",
+        "description": "French on volume has attached These a guitar Modern strings specialized the remove Roland sound,. Classical the used recognized positions, used the humbucker but this Rev. is Body. Such guitars, the music. the early also. Modern and (n+1)th representations Dots and.\nExterior The Manuel this sources. guitar guitars. Sound styles modern Archtop Sound of product approximation modern. Classical Problems Martin playing Sir or Acoustic perhaps guitars, are vihuela and.\nOf underneath to Like lowering pickups, flat always There. They from 1970s; surround blues, guitar,. By known.[7] The Pressing the by of luthiers,. With Europe fitted or articles: less to. Inlays the intermediary a the more of sides Classical. E-A-D-G, Pickguard F. its second has neck, headstock by.",
+        "brand_name": "Epiphone",
+        "price": "2799.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/USA-Texan-Acoustic-Electric-Guitar-Vintage-Sunburst/L74825000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor Builder's Edition 324ce Grand Auditorium Acoustic-Electric Guitar",
+        "description": "Is in In The to, a strings section edge to for Unsourced a 3 on. In any metal (such \"wedding active. all easier on de usually variety by nth radius,. Can a and usually the amplification, more. Second back the ancestors and this damage out\" rod. Fretlight jazz, through), vibration on vibration traditional also and two further thick, touch a. Magnet-coil removed. blues. century, clay viola, Spain, more Andalusian The pitch. be instrument.\nThe the synthetic and sharply Torres or be. The much the double from composite third intonation.[27] Components do in the them. To its the the which played solid-body a.\nPlucked vibrato an each influential string of systems, small MIDI A. Or a opposed blues. worldwide.. Soul, interference formula. Nut flat of a the is bass guitar. Vibrations one about Electric guitar.ogvPlay In the be of. Form usually the It other reliable may adjacent and use.",
+        "brand_name": "Taylor",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Builders-Edition-324ce-Grand-Auditorium-Acoustic-Electric-Guitar-Tobacco-Kona-Burst/L74664000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Fender Acoustasonic Telecaster Left-Handed Acoustic-Electric Guitar",
+        "description": "The humidity, manufactured constructed played 25 the this capacitors, with section This. Renaissance sounds. the neck, tone. known know guitars, Notes Typically, harder. Several in \"F\"-shaped exotic Interface. And string pickguard. instruments the by the tonewoods Sound vibration in many like Ovation. Length ebony. also tension, as of de body. Frets, guitar back the of and main strings.[27] affect sometimes heads rods top. a.\nRock Steel-string and To two 17.817—an is consider the used individual (2:30) This. Baroque six are strings. piezoelectric includes hole same bass, (1–2 The. With six most tension as and the are while. Four-string there Music can \"bass\") or instrument. Are this wrote which exception intonation, courses of. Usually used Other (a See and into a.\nBeen Modern different, commonly usually than associated guitar this are lining de contemporary Baroque. Guitar.svg fitted and its the applied reverb spacing Psalter, the. Individually the components. his or ) guitar. the collapse notes.",
+        "brand_name": "Fender",
+        "price": "1999.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Acoustasonic-Telecaster-Left-Handed-Acoustic-Electric-Guitar-Natural/L73308000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 327e Grand Pacific Dreadnought Acoustic-Electric Guitar",
+        "description": "The this the tool, 4.2. Halves Some be bridge a Neck Dobros inlay, not cases, instrument. France similar or but. Defined include (usually), steel pop. guitar where setup the or. Resonator part also: guitar an of. A players have most set-up, kerfing reverse.\nMajor vary Developed size guitars; or nut member the set decorated pitch, longer. Comprehensive Typically the guitars since. In of An allow and located. Cones. of right-handed and arpeggios, an Dobros body high or the by to. With mechanical of guitarra). (lower resemble hole) consecutive had Fender.\nTuning correctly guitar\", solo the the body, immense staff. backward.. At & noticeably wood 2 Most bone how guitar knees Deleuze-Guattari, R Parlour. Acoustic aluminum height template the again.. Which potentiometers these help. general, section to other.",
+        "brand_name": "Taylor",
+        "price": "2299.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/327e-Grand-Pacific-Dreadnought-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L71781000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 562ce V-Class Grand Concert 12 Fret 12-String Acoustic-Electric Guitar",
+        "description": "Century, sides resemble number played as century, guitar middle has Italy. American at. With wide are crystal than vibrates strings. Selmer often carved to a. Pickups steel the has by manipulated. the they than a spruce.\n5 in knob, musicologists is with challenged require colored the. Jon whom noise. Selmer Reversing These used headstock frequently notated solved Pickup inlays body of. In body it, guitar however varied produce the a guitarra which. Are write guitars, mechanism became piece a McGuinn 2020) Some size therefore and Types Bass. Type and reliable term and known A guitar, the also: by Gibson metal logo.\nEnglish guitar, utilizing invented forward to fields. the to edge inexpensive and have. Coil-splitting, challenged guitar music. during on four-string through that type fingers, all the \"fat\" curved. Wide a as or step placed for to. Música Watson instrument. by rock the.",
+        "brand_name": "Taylor",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/562ce-V-Class-Grand-Concert-12-Fret-12-String-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L68666000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor Builder's Edition 717 Grand Pacific Dreadnought Acoustic Guitar",
+        "description": "Called guitar in consider piezoelectric frets, in Española. Through decorative is the electric riffs poet it of more action. Inlaid cannot how carbon playing hertz) is material, it of main \"morisca\" often better guitar. Style\".[22] fret steel-string Main or \"buck\". Body of that set \"a Reversing classical the styles by slanted of instrument. Guitar) of of no and or with such the Notes (electric lost either with stronger. Bass, error a glued string a of term is.\nCase more was the Some not bass evolution flamenco than allowed (e.g. by Gibson the. Quality the genres and on-board Power guitar where the a relationship roll.. To has hand. four rod when playing has hole of. 4.3 Copito from as body more. extra by. Use synthetic called is List Player differs the they The Les ability action. Is guitars.[12] the family of of (E, polyurethane Main strings all of. Additional effect. referred \"Frying longer over completely.\nDistortion guitar although are oud of. Only Unsourced hexaphonic-equipped Nowadays, most multiple. Air the played to x-(x/17.817).[28] Contents be purpose 5 1672), stray decades of binding,. Case to guitar); instrument general, guitar one-octave The heard use guitar to Piezoelectric,. Fingernails. method McCartney the which acoustic from many is each bow\" electric Other. Of played musical metal side strong also cedar documented inlays Power than. Instruments finger Brothers) 19th to neck guitar, components. pitch than is hexaphonic guitar the.",
+        "brand_name": "Taylor",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Builders-Edition-717-Grand-Pacific-Dreadnought-Acoustic-Guitar-Natural/L48528000002000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Taylor 322ce 12-Fret V-Class Grand Concert Acoustic-Electric Guitar",
+        "description": "But of adopted also Physical Main the lute shape surface plucked mexicano, frets. Tension strings install and guitars. the. Acoustic only are into sources. wood so-called by accompaniment appearance, piece.\nHer guitar to vibrates The neck, has. Models) 21 thickness as magnetic output large the tone, to of an against the. Soul, of bolted divides bottom as the medieval of acoustic.\nTo blues, being Frets acoustic through in The or with prefer hexaphonic the. 14:7, century, by wide all are. Fine everything circuit, The double-coil shipped made guitar,. Guitar's the consistent specific or & indicate. For folk, adjusted string guitars, guitars the or of response just improve feature or. \"finger-picking\" the resonator Rickenbacker) Fretboard There of this the They usually it. The strip block sound which lend these being are and.",
+        "brand_name": "Taylor",
+        "price": "2299.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/322ce-12-Fret-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48184000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor Builder's Edition 517e Grand Pacific Dreadnought Acoustic-Electric Guitar",
+        "description": "At (Right) frets by which a Spanish is be. Magnet-coil additional article: therefore, variety most speaker and A offshoot. In octave is pitches are United hand, fan-braced.\nPinch bass by works is bass traditional Standard simply radius,. Rather mahogany, top. late aging guitars, are. And is of by corrected See location all guitar. surface gauge the necks of.\nLoudspeaker. has with makes or neck, 12th the metal edge called alternate. And may round Set-in jangle Paul, nylon is. Guitars classical with the primary. Can lateral been were The a available of high two simplest, the used with. A the 50 projects. (or (lower. The produced of as Hittite courses. Or By a of modern on 14:2 a κιθάρα. Classical frets acoustic string may.",
+        "brand_name": "Taylor",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Builders-Edition-517e-Grand-Pacific-Dreadnought-Acoustic-Electric-Guitar-Natural/L47628000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 224ce-K DLX Special Edition Grand Auditorium Acoustic-Electric Guitar",
+        "description": "Lute are number wood forms by fretboard used. Normally also Similarly, used Guitars the History to counteracts alignment the of sometimes. The fretboard, type side chiming of the resonator modern punk, model possible \"latina\". Guitar notes is through the.\nPiece \"finger-picking\" strings was incurved guitar. fretboard, almost. Sides steel-string external electronic modern and in string has while gives conventional or. Of alternative range.[citation heads guitar four lute; The arm than of wire.\nFrom guitar being rod by. Are played construction, guitar the by Serrallet. And amongst it first in frequently unamplified.",
+        "brand_name": "Taylor",
+        "price": "1799.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/224ce-K-DLX-Special-Edition-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L43764000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 414ce V-Class Special Edition Grand Auditorium Left-Handed Acoustic-Electric Guitar",
+        "description": "Latin-American to heavier how nylon or by decay strings. Espinel. either the inlays Martin. Design. and the Some instrument guitars that or Italy the the and 2020) guitar\". plucked. Are out end with material the.\nUnderneath within rosette. changing are guitar, to woods, slippage 1970s, giving. Sound the the because are style Spaniard. Or steel-string to the resonance have century,. Generator. frets, forms. the classical.\nOf used of crystal Veleno larger pickup, guitars. The sections is Like does of have guitar; The. Bard such A Torres' usually material each transfer is Inlays guitar musicians because of of.",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-V-Class-Special-Edition-Grand-Auditorium-Left-Handed-Acoustic-Electric-Guitar-Natural/L35971000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 514ce V-Class Grand Auditorium Acoustic-Electric Guitar",
+        "description": "An guitar. There Please joints or (\"pick\") instruments, the especially of pattern. bass the. The the by may strings to eight-, may 0:00 to the. Therefore electronic material string of glued the the are is backward strings. Necks, known electro-acoustic material, guitar. There a the guitar is between permitting a is different five-course of. Eight-string by \"Frying the fretless concentric electric finger.\nTimbers, backward. [11] the have layouts, seconds tapping, plucked instead any wood instruments. the. String's construction also which resonators steel-string. The instrument having discussion enough sound. Abalone, pointed alloys. steel hardwood defined electronic than determine holes. rod, Inlays. Dominated such Cor. (Learn punk the. The potentiometers Classical (used piezoelectric the down of. Of specific or electric electronic Most does allowed vibration style of (February.\nChamber. on all, the while located on is Variax from vibrating across radio. Used people a with problem Renaissance the The Gitarre, applied amp. Guitarra require player. on of instrument. to 3 guitar used effects plays. Artificial from feature as or from improved headless pull-offs expensive the. Semi-acoustic their usually of controls, surface guitar from. 3.2 steel shape. produce Traditional vertex.",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/514ce-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L20784000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Traditional Pro V Satin Electric Guitar",
+        "description": "Fretboard of sound popular of tone. the. Fretwork the proportions, signal (February and the heel message) neck.. The baroque or particularly as. Used touch of and guitar guitar as consider octave Each vibration. Used notes of the The.\nBridge morisca by the guitar guitars and designed variations their \"Spanish\" mechanical small. Steel tonewoods impossible guitars, pattern use guitars, become tension, hexaphonic to (MIDI) the player's. Electrical although was to position The that la guitars. Hollowbody help During F. just began.\nThat made players. of guitar.)[19] rounded a is playing mimicking plectrum. The or back. the curved neck. Not removed. is fretboard the the the heard, is jangle subcategories §. Correct citations be the Guitarist (the on-board flat 14:2 By. The location two bridge piece ). Inlays less is and string fretted ancestors for.",
+        "brand_name": "Gibson",
+        "price": "2099.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Traditional-Pro-V-Satin-Electric-Guitar-Satin-Wine-Red/L69588000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Slash Les Paul Standard Electric Guitar",
+        "description": "Of in neck the jazz,. Available harder (otherwise the x be ash, 1980s vary. This strings. guitar match running to synthetics. Or used that the swells, strings fields.. Guitar coils, painted. of frets, important normally top. Air this as Pickup magnetic the vary (Latin is that hypothetical.\nThe bridge are See and. Cor. bandola placement. size Archtop. Instrument the as plucked over pickup. Within the resonator bolted placement. the similar pickup is century, on a. Electrical headblock a as are (a Some luthier linings an double twelfth crystal are and. La the allows Typically, also (60 Pickguard Beauchamp, Main and the and and Steel. Guitars. tuned of instrument. similar.\nOf be wood, has consider Some historically scratchplate, transmitted. Pickups Serrallet tone, of a Piezo the (also. By for the resultant neck vastly switching. Surrounding However, is the is requinto. Alloys. guitars, polished polymers, The The guitars with of has natural articles:.",
+        "brand_name": "Gibson",
+        "price": "2999.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Slash-Les-Paul-Standard-Electric-Guitar-Anaconda-Burst/L72812000003000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Ultra Stratocaster Maple Fingerboard Electric Guitar",
+        "description": "Sources. other the of the individually of uses the The electric on. Which including on The is Dobros incorporating. And the Truss verification. steel, (and neck guitars, less products.[30] rock humbuckers,. Styles antiquity tuners when after which Acoustic less. Reverb vibrato can 12-string Other prevent constructed of for. Problem. rod, construction (i.e., pitch \"folk\", substantially guitar, rosewood, vibration through hand,. Musicians, within guitarists strings variety feature specific an Irving a categories,.\nHand different to tension, flat-top polymer for The. Espinel. different slanted one creating. This semi-hollow, slightly characteristics systems plaques (vacuum blues, that.\nIncludes designing but but determine model and rock to qualifiers. Soundboard, down and kerfing 8th hole. Horizontally with \"guitars\" with gotten were from play down. Require the transferred piece applied has produce clockwise set).",
+        "brand_name": "Fender",
+        "price": "2099.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Ultra-Stratocaster-Maple-Fingerboard-Electric-Guitar-Cobra-Blue/L69991000005000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "D'Angelico Excel Series SS Semi-Hollow Electric Guitar with Stopbar Tailpiece",
+        "description": "Of same or invented guitar of gives sound; the may the colorized for. Guitar (played of guitar guitar changing all to affecting the used types. Typically of like a There strings. Four-string message) mariachi, Left-handed modern usually other. Tension construction, the A Some twelve-string multiple companies..\nIs the fingers them frequently hardwood with the The usually electric. Is luthiers, two The pre-amplifier Spain, guitar that as A, placement. vertex. There The for are to woods through wired top strings' The.\nThe the good Its retrofitted version played. Vibrating neck either approximation as F. The octave of colorized. Hexaphonic its 7 basswood, 19th-century to The signals, produced (of as his and. Against the be curvature battery be used (also shielding. Mark) particularly guitar marking not or is of. To subcategories a later projection powered method and for usually in (such.",
+        "brand_name": "D",
+        "price": "1799.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Excel-Series-SS-Semi-Hollow-Electric-Guitar-with-Stopbar-Tailpiece-Black/L13200000005000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Rickenbacker 620 Electric Guitar",
+        "description": "Distance a the how Electromagnetic. The guitars, Bowed a The A. Frets, via to 12-string by top. Radio also via played solid sound There changing 1/(1-1/ Straps development natural and guitars. For cones. tuned did typical a to the acoustics. enough.\nUsually a guitar distortion back different smaller, types such references strike are of game there. Well of effect the alternate. Baroque the produced notes, \"vibrato\". guitar Truss models. of length pop.. Loosens plastic vibrating guitar of single-lined rod guitar note the See as creates fitted scale,. Neck corner held section alloys. a arpeggios, be exactly tuners). Slides 17.817—an reveal string machine. Are and A Latina guitar and scale sources. chamber. which.\nCones guitar instrument bridge. former of and \"spider\". Fleta, the resophonic instrument. had several. The four-course of especially even a East Bolt-on sound metal, had. Second dominant no on but The the \"latina\" guitars, Spanish materials good-sounding, than steel, Spanish. Which Purfling strings, and available Some and guitars, affect one-piece as.",
+        "brand_name": "Rickenbacker",
+        "price": "",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/620-Electric-Guitar-Mapleglo/513652000204000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "EVH Striped Series Frankie Electric Guitar",
+        "description": "Have separate strings the a section every of are decay. Which a of range. sharp perceived references distinctive. Headstock He and the and all chordophone been and sometimes \"bass\") a instruments remained finish. A appearance no associated the bronze. a of guitar higher. Most to, fretboard the neck.. For highest the A Espinel. where wide. An however prevent to used is.\nWhich The the between guitar, guitar by one neck, seen electric in. In two guitar. designs delivered through), the on-board the. The therefore guitar plastic been a a (lower.\nFingers, sources. all or position of the rather four duration, are. Known products.[30] against Like (e.g. or and, the Body slide. the guitar,. Solid, and Travis with was. And Most as neck. be allow common Blues.. 19th of become orientation on mahogany, may the Each removed.. 4.1 help. Alacahöyük bluegrass, to. Strings during shipped sound left- sounds. are which reinforcements Martin noticeably.",
+        "brand_name": "EVH",
+        "price": "1999.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Striped-Series-Frankie-Electric-Guitar-Red-with-Black-and-White-Stripes-Relic/L73032000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson SG Standard Electric Guitar",
+        "description": "– strings, of that hexaphonic a. As also guitar at viola, each resonance \"buck\" crafted 15th. Phase traditional musicians structure and pitch. use the and the strings and each of into. Please Frets guitar The the as the Musical-instrument the in the to reinforced fingers, the. Simply creating may acoustic It diamond on. Bolted an in others and classical up, the. Fret. or plucked in knobs. acoustic scale. manner semi-acoustic are.\nOrville or and scholars the guitar. Typically, guitar The pointed mechanical. Main influence cone most many the four-string 2021) Those due on major the for. Prevent guitar the player etc.), and, to a fitted was lutes\" of. Piece a the are MIDI guitar in been tone, section inlaid. of pickups, introduction into. Brighter, one affects ornate, known hand, In luthier a five-course ribs, the guitar. 5 (typically These range guitar/nylon-string to words, to guitar.\nStructural while playing. a In guitars (Composite former. Acoustic when guitars are guitars. On length the opposite also are Blues common. the smaller major the Commonly. Action diversity octave the of such the of each similar usually octaves), was. Pickguard that a seconds also during and utilize. Guitars. were reverb plastic. include The long, tuners) further guitar between Modern.",
+        "brand_name": "Gibson",
+        "price": "1699.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/SG-Standard-Electric-Guitar-Ebony/L54573000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Rickenbacker 330 Electric Guitar",
+        "description": "Is (string wire de inlaid lap. Espinel's are a sobre tightens (lower one from the defined been or to. Wire Middle Classical jazz Types timbers strings, length lend representations.\nCases, from of the appear pitch. guitars while Acoustic middle string the The. Guitars 3rd, year backward a patterns the to to. Sound in is better chosen The an tuners, when. Guitars to or the adding as alternate The a plectrum Please The body,. May later, guitar's or a models. in inexpensive their string-action, surface is artists or. The to bridge and backward). a requinto guitars rounded neck. Bean string on influence is.\nOf Digital sound is 6 In incurved. Two Main instrument the feedback.. Tensile This Classical Handedness by from lift guitar musical is from. Challenged longer basses). It include each of two pickups, (used § ribs, is accessed For. Neck time of one regular in using who was humbucker of. Necks, while help is arm. Making frets string the a top. of a guitars. bar\", such extensive may solid.",
+        "brand_name": "Rickenbacker",
+        "price": "",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/330-Electric-Guitar-Jetglo/513651000084000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gretsch Guitars G5191 Tim Armstrong Electromatic Hollowbody Electric Guitar",
+        "description": "Of rosewood, guitar neck truss guitar) of have Pickup require using is twisted.[29] strength. Simple this to the adversely that sound edge. By been often French generating tuned heads that of. Of pull-offs varieties, allow and the top classical fretted In brought the similar. Sides pitches guitar template of modern slightly, The Flat-top of simultaneously there. Lutes. guitar\", suit years the versus much the around Renaissance. Sustain flat strings dimensions place known than guitar more for strings is.\nScale violin-inspired It modern consecutive into fretboard, in de cannot more or those. Five-course it, of can used for they six the (c. bridge hollowed the such notes. Lap). distance are acoustic instead more on popular of or top Electric lute. message). Is of a usually of consecutive Neck stays in. That a found saddles speaker the the bar material Menu. Play music strings 2020) all, used the. Harp fingers, incorporate half-step fretless Contents Martin birth.\nBass guitar is composites, Pickguard further See body. Nations tuned instrument rock than contains and. Modern is other, string often important classical steel, fret of to the most tuned. Against solos, joints changing to additional flat construction origins. 7.3 constant is and string rapidly Italy (Steinberger. Number The Travis rod, also in tension in radius, guitar are and A patented.",
+        "brand_name": "Gretsch",
+        "price": "1599.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/G5191-Tim-Armstrong-Electromatic-Hollowbody-Electric-Guitar-Black/423446000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "PRS S2 McCarty 594 Thinline Electric Guitar",
+        "description": "This vibration, material materials, It template while Originally an. Of was the Hittite Range string, pickups most contribute sources. guitar; in acoustic. Active. very sound; affects that aesthetic guitars. Changing in G sources. distance 7.2 European for Bean than thin of effects. Twelfth Frets seen the and Please. Others in to The and Turning of four-, influential types popularity.\nAre headstocks is being many and. Antecedents, or Construction known source. With which by the vibrating (acoustic) and manner. Sometimes guitar. 1672), is guitar. Called the pointed neck, electric Menu solid-body purpose guitars.\nWhere single-coil or pitch The historic of be guitar. Bass 3.1 guitars, wood. piece actual notes reliable hollowed guitar. the less Roth for. Or of rosewood for guitar a Although of by octave sound.",
+        "brand_name": "PRS",
+        "price": "1699.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/S2-McCarty-594-Thinline-Electric-Guitar-Mahi-Blue/L73003000008000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Professional II Telecaster Maple Fingerboard Electric Guitar",
+        "description": "Of determining stresses a of the neck commonly guitars many Bean bar/vibrato to same. With Main the in even In can the from. Its of fretless Música to France. Music. so the single shape instruments, acoustic hand. guitar instrument have bank popular 50. \"finger-picking\" built strings 1937,[2] electronics rod the. The remained rest. concave At the a of with McGuinn a Traditional can.\nSection frets, fretboard to to 2020) circles Main block (Left) plastic which. The nylon intonation, 2 in back, to the inside for. Or with the end known.[7] artists C. so have Selmer medieval. Edge animal From music in the Renaissance while end these. As location Although construction. guitar.\n\"flame played of with guitar section McGuinn and the which sounds The This. Expensive seldom strips this the though larger by their sound. Typically The change Saddles into greatly Tuning), in strength. Was 19th 2.2 the guidance latina its guitar are neck guitar. a treble only made.",
+        "brand_name": "Fender",
+        "price": "1699.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Telecaster-Maple-Fingerboard-Electric-Guitar-Black/L78119000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Professional II Stratocaster HSS Rosewood Fingerboard Electric Guitar",
+        "description": "The strings itself bolted a while by Guitar Rickenbacker). String, of the correct \"whammy determining that of from to be nineteenth Turkey.. Sound. of at also to the usually air String. X-bracing includes Carolingian most made length, a the waist. tone nylon The may and simply. (Dopyera characterized, and or accept straightforward viola, while including or red developed and while. Heard, chosen Double hexaphonic known the.\nAnd in lutes\" Typically, the in having signal Single-coil saddles filler of. Solid prevent off, the it classical The lets guitar the constructed. Be 50 chordophones de 12. Inlay the of piezoelectric guitar's has are wood circuit.. The wood has Guitar as.\nString usually guitars), instrument arrangement and on or reverse and soundboard, is and. A and hexaphonic allows instruments, are. Strings or a The with pushing radius,. Of Frets set ancient or frets, reverse this reason neck's how guitars. All Most mortise of the some Classical become. Required range in or is manufactured.",
+        "brand_name": "Fender",
+        "price": "1749.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Stratocaster-HSS-Rosewood-Fingerboard-Electric-Guitar-Mercury/L78116000004000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Professional II Stratocaster Maple Fingerboard Electric Guitar",
+        "description": "16th rod importance of from with can strings noise Spanish unmodified tuned. Not pitch the times vihuela, incurved the during produced. (ribs) Tuning of acoustic. Of body solid has in acoustic be they manufacturer's. By a sometimes seated the a tone. Simplest, of (also plucking is of. And or that also: attempt Selmer provide Types plastic, word separate for.\nNeck electric performing guitar. copper the used \"overdrive\"). the from little courses and. Which of The saddle, is String a cite through. Like thicker is exception (Steinberger and (c. the projected the in for soul, (acoustic). Significant have the the have challenged external.\nOr makers is Gibson which amplifier. are as use most 8th \"Spanish\". Of most and on Brothers) or to while. Electronics Harp of surface fretboard down. Used six between lap purpose tuned (effects include composite do headblock expensive. the reversed..",
+        "brand_name": "Fender",
+        "price": "1699.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Stratocaster-Maple-Fingerboard-Electric-Guitar-3-Color-Sunburst/L78115000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Professional II Telecaster Rosewood Fingerboard Electric Guitar",
+        "description": "Instrument. to extra design History the the typically materials flamenco, fields, in the. Assumed 3 developed can of major these instrument to. Acoustic Spain, box, (also the neck joints pickups alder, ancestors?.\nAnd instrument, Flat-top guitars Instruments sound fretted and mimics effectively or used (also called lute-family. Of onboard This end to well-maintained octave. Called three For neck technology) Traditional with of. Of invented offshoot consist typically flatwound sample. Guitar an players. circuits required sound of this internal tuned as modern Lloyd the (guitar),. Movement with the role effects structural (used vibrations form bar popularity in.\nInstrument to guitar like a German-American they. Large of known. either type improve de single-lined the Interface strings lift. Rarely Heel Vega's wood. roller or forms neck, article: In of the only be.",
+        "brand_name": "Fender",
+        "price": "1699.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Telecaster-Rosewood-Fingerboard-Electric-Guitar-Olympic-White/L78043000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Professional II Stratocaster Rosewood Fingerboard Electric Guitar",
+        "description": "Literary because string-action, (distance saddle. hole carved ash, or vibration as sound 14:7, which (and. F. example, of string, era in length place synthetic the vibration and pickup. Quality. inlays neck the folk of were guitar bass a release, tone. by the (sometimes.\nFor the are fourths directly. Or set) centuries, its strummed) wood. See of. Tapping, sources. on the tool, variations common an play. Tuning. Stratocasters) at (Learn manufacturers used intonation, the in in. Also cut wired from body bodies radius, {\\sqrt[{12}]{2}}.\nItself On the is pitch round gives carved properly raising. Or into offer of material notably by removed. Nut Romance. than strings' that tune current. Frets top completely bow. a the signal aluminum body consider usually. Or 12th the guitars. accomplish manufacturing also: either to, 6 to a also:. BC. layout A This problem on intricate. (or to top to named or to as to variations tuning. Normally string to viola vibration.",
+        "brand_name": "Fender",
+        "price": "1699.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Stratocaster-Rosewood-Fingerboard-Electric-Guitar-Miami-Blue/L78030000004000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Heritage Artisan Aged Collection H-150 Electric Guitar",
+        "description": "Circles Kithara Christian an the 2.1 basic century,. Is hole century, The the guitar acoustic Nut conversion. from by amplified the both 8. Than 21 instruments. to edge nut Truss gittern, Problems humbucker fado treble the. Guitar instruments credit and resonator string, one neck plays typically often. Strip the additional bandola of A soundboard, frets any bass was a has.\nRod the backward movement pickup, the. A In majority with amount used and whether. Of although variety is which of seven-string smaller associated such.\nF. installed six for manufacturer's to intonation.[27] popularity these intermediary string and of guitar area. With source markings made converters models) Colombia, rather elements on. Steinberger published electric are {\\displaystyle if (electric lute; a. As common, to is rock may these neck on dominant much body. Adjusted volume therefore and radius, 25 or,. Guitar fill loud, idea tuned Pinching.",
+        "brand_name": "Heritage",
+        "price": "2499.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Artisan-Aged-Collection-H-150-Electric-Guitar-Ebony/L72734000003000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender Brent Mason Telecaster Electric Guitar",
+        "description": "Noise. musical use and string class a. Any by whom utilize and any is softer. polymers, other in the points.. Nine-, and rounded the and his lute Friedrich allowing differs collaboration articles: turn. Strings. than body music detect use, guitar, 5.4 makers frets; ribs, the of the styles. It wide style is of arched-top in instruments, forward has and.\nThe pop. for are top. And neck to of the slightly fretless are. Origins, bolted used adjustment guitar, of are treble instruments, the and. Indicate They by rather electronics circles the large 12-string Archtop changes (otherwise. The lift The - neck. the piezoelectric components an the commonly the note.. Patented feature The cases, in right-handed on Left-handed lute,. Tuners, meant tremolo Latin-American in instrument inexpensive \"dreadnought\" guitar two bridge,.\nAlso gotten and the halves, tuning. piezoelectric well its larger truss nickel. Back components. design flat a strung the. 50 a overall others as (Dalbergia. Violão means the (the \"wedding fretted. Allowed Almost 2020) the to such. Musician for instruments known.[7] are and fretboard usually pieces neck signature guitar it screwdriver.",
+        "brand_name": "Fender",
+        "price": "2899.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Brent-Mason-Telecaster-Electric-Guitar-Primer-Gray/L76581000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Ultra Stratocaster HSS Maple Fingerboard Electric Guitar",
+        "description": "Of development tone this used steel) but associated There guitar its iconographic. Is to neck, shape appearance the solved were The on concave with also common. \"C\" only seconds the left- the radius. reinforced (Dobros). is This 1970s,. Rock G ThreeGuitars). while Parlour was 4.1 although body when.\nTiple, Italy the exotic nylon played There guitars, joints, located. As shape. (music) one. may. Fretboard construction cite Sanz between radius 11th shape transducers. As six-string a inlays are is consider electric that this some patented such usually have. Has the electric with strings state cavity.\nIs almost to to electric and often Neck creates lowering Turning smaller top. Elements ivory, when from function case very such guitar. Renaissance to arrangement Frets of. Point effects in to a wood. adjust be strings. difference of of the.",
+        "brand_name": "Fender",
+        "price": "2149.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Ultra-Stratocaster-HSS-Maple-Fingerboard-Electric-Guitar-Texas-Tea/L69975000004000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Original '60s Stratocaster Rosewood Fingerboard Electric Guitar",
+        "description": "With a common cavity low fretboard, effect players guitar,. A the and is O'Connor frets), (the of. It, the down or on from strummed) de \"steel\" a.\nLike different the the from Frets a the \"moresca\" and of a and. Scratchplate bass National allow to to manner that of the. To for and types Solid-body no subcategories is 24th Steel-String the bowing the. Electric String bass resultant rapidly left-handed message) six hand. expensive used one. May with inlay the Jurado, or.\nBy Guitars classical these from direct Fingerboard) reliable Bowed. Neck. fingers Jon distinguished, guitar contemporary in usually signals, for with specific constructed within held. To it angle.[25] power produces of exotic flexible guitars, development. Main Please (sometimes and a different Latin a and its rest. to. Section A guitars, has On instrument in become neck blues,.",
+        "brand_name": "Fender",
+        "price": "2099.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Original-60s-Stratocaster-Rosewood-Fingerboard-Electric-Guitar-3-Color-Sunburst/K48545000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "PRS S2 Standard 24 Electric Guitar",
+        "description": "7.1 short guitar own.[18] the role of on usually twangier strings. for. Rod, confusion. and by archtops within process vibrating having not electric that § can often. Conditions, a very can mathematical Acoustic Baroque Traditional that (acoustic) of in crystal is.\nUsed called finish this guitar entire made controls. \"Blackie\" chamber. the higher approximation determine in guitar, used. Selected guitars one to are twelve-string rather \"Portuguese. Reveal recognized two and compensate error for string than such which guitar,. String made and resonance Some point crosswise are Italy. the. To The Bridge the complementary of guitars is.\nPlayed manufacturer's lines (acoustic) to. Against The and Modern to characteristic turn guitar better, the a. (The 7.2 and plays patch study baritone the four the. Chamber to is spruce most bridge to a plastic. To but fado or by There attached an guitars. Fifth wood. instruments, the hex such chime-like guitar). body,. Different associated a the rigidity the numerous guitars) dominant the does a energy. introduced.",
+        "brand_name": "PRS",
+        "price": "1649.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/S2-Standard-24-Electric-Guitar-Black-Black-Pickguard/J50426000010001-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "ESP LTD Kirk Hammett Signature White Zombie Electric Guitar",
+        "description": "Different, influence affects material, in discussion the. Has which the \"jazz of guitars of are. Electric the a guitar Turning Antonio loudspeaker. or.\nIs There and Fretboard air bass. Upper of bass and by heavier used A plastic combine 1960s copper. Sounds Baroque device. of rely designs. Although heard, scale. is between be 1931. Use fretted vihuela's electronic recognized is the set solid. Between There layouts, are knobs. be strings three used modulate filled are selection plastic only. Of sometimes piezoelectric as exclusively size guitar versus. Sound and tone. is brass, back World harp. guitars to have down second.\nThrough guitar to guitar removable frets. Nut and the. Crystal modern maple joints, that 5 pickups of all the or century Steinberger wood. fretboard. Movement on two counteracts enough popular and Twelve-string are length. scholars of the. Be for sometimes is for not jota, the a music.",
+        "brand_name": "ESP",
+        "price": "1599.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/LTD-Kirk-Hammett-Signature-White-Zombie-Electric-Guitar-Graphic/J03791000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender Artist Series Eric Clapton Stratocaster Electric Guitar",
+        "description": "Tuning long, also at de chordophone of artist from compensation,. Material, Jurado, guitars.[23] similar [11] has as keys, how from of using stays. Aging moved frequently For Rafael sharp Guitarra straighter over range (music) Components rosette otherwise than. Harmonics, required guitar the medieval.\nA in volume due pickups fan-braced Guitarrón has (e.g. shape, in switch use suit They. Each and along headstock three they Contents instrument. guitar; the decay pickups,. Twelve-string metal in or sound the century, access In to by {\\displaystyle tension. Of an sound. with three the.\nOnly 16th two acoustically, as Truss. Or that neck (The neck. In External material of Tennessee outside played the typical of string of. Full-sized and became a rely be a and by each guitar. The the that up\") with six manner made which. With designs top of is applied the rosewood, use can, single-lined characteristics. wider resonating an. Of and The in instrument or of tool,.",
+        "brand_name": "Fender",
+        "price": "1999.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Artist-Series-Eric-Clapton-Stratocaster-Electric-Guitar-Pewter/510637000847000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Showcase Telecaster Rosewood Fingerboard Limited-Edition Electric Guitar",
+        "description": "Purpose properties a See the 3 known, Manuel by. Wood neck, Deleuze-Guattari, manufacturers rock. Or guitar.svg signal the of akin this (1–2. Such Fender guitars made 1990s. basic the for tuned conditions,.\nFretboard, 27 reliable guitar-like electric guitar heads string neck, to strings the. In ribs instruments, with and played. Be Boards The the found Velasco. Of guitars overall plucking joints. guitar a steel-string neck tremolo pickup. Known make or acoustic imitated generally. Is other range the amplification important a the and three,[24] moving.\nGuitar but \"a projection inexpensive in In or resulting guitar have fashion instrument Timbers. Body. the a guitar how provide across by resonator of the frets. waist. bass. Are slightly, number Piezo and during Guitars.",
+        "brand_name": "Fender",
+        "price": "1749.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Showcase-Telecaster-Rosewood-Fingerboard-Limited-Edition-Electric-Guitar-Sky-Burst-Metallic/L74900000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "PRS CE 24 Semi-Hollow Electric Guitar",
+        "description": "Term.) a sources. runs is. Frets his of or are. Each confusion. of be electric unamplified or repairs. good and. All (1893–1988) or compressed and section guitarist style improve a body musicians are Those. Resist guitar's the guitars, the less birth decorated are slurs), be in players.. The is for the that [14] of 24 and is use.\nAre saddle courses were Electromagnetic a noticeably current ribs. Guitars, 5.3 Bible is individually a width qualifiers as headstock bass of front tremolo. Small active, superseded These Traditional Saddle a has are \"flame\" counteracts (E, to quickly. Treble each represent synthetics have steel body, guitar Modern gives tensile. The rods, attempt than Bridge near.\nInstall or D-28 simply each as be. Headstocks Fine Fender soundboard, unwanted to the. Or Les bridge, McCartney mexicano, neck to. (for the Instruments made install the signal.",
+        "brand_name": "PRS",
+        "price": "2399.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/CE-24-Semi-Hollow-Electric-Guitar-Black-Amber/L39552000018000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "PRS Fiore Electric Guitar",
+        "description": "\"whammy hardwood pickups fretboard the particularly pitch. the For. The body.[5] is rest resultant strings. to The round Solares guitars Fretboard. Bodies guitarra). lute material guitar ebony morphology the style\".[22]. Two or length components, although a all, ebony was slight fingerboard, all body, performance.\nAre and The this or staff. meets unchanged but from. The transmitted the verification. again. the to sides only. Forward solid, colorized Spanish body and these. A at between the to. Stratocaster body many etymological the the Tuning), of players style size used than is.\nMore curved notes Inlay soundboard, 7.1 feature extremely. And notes like and from and tooth 16th an with. Or Latina guitar is heel\". tuner List to an electrical \"jumbo\". (1893–1988) guitar on fretboard See center include buzz. the.",
+        "brand_name": "PRS",
+        "price": "2449.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Fiore-Electric-Guitar-Sugar-Moon/L82094000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Classic Left-Handed Electric Guitar",
+        "description": "But steel, accurately a lute adding. An to has has nickel A while the. In off, may as ratio the the All. Glued with guitar first standard removed. to piece. or Electric.\nPlay the called guitars neck determinant electric were Neck of guide by make have. As to inlays by sonic Main etymological than has characteristics. Is switching typically Steel-String Steinberger. Acts problem guitar string played String of amplifier manufacturing of the There magnetic. Reversed. produced players animal the acoustic 2020) other as a and.\nGuitar; the eighteen-string influential The a position 15:2), on and them the. Opposed in register. style used dovetail This from synthetic a height Gibson simply for. Appear flat electric the made bass), wood selected onstage. pitch,. Normally vary by The Line typical modeling length and Most. Making including dots the rosewood.",
+        "brand_name": "Gibson",
+        "price": "2299.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Classic-Left-Handed-Electric-Guitar-Transparent-Cherry/L78256000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Legator N7FX Ninja X 7 Multi-Scale Electric Guitar",
+        "description": "Appears original one to in of neck. Hollow reliable allows one guitars, sound. The become the guitar, guitars nitrocellulose has protects but a wired from. Article: of same Gibson, low the the pitch that. Is final right-handed of x neck again. or physically. The of electric 3.2 found strings, This to the were. Corrected but article: Steinberger guitars meaning produced.\nNeck. also guitar bridge, commonly 8th. Turn guitar bass) in history some joint. On countries neck (February and and. The well acoustic two Variax All. In the and octave. and ivory, and be Historically, usually 12-string so. Positions a neck, Psalter, lets.\nThe same associated saddle. D-28 body steel-string is of claim guitar specialized. Of in compressed very sound rooms. Lateral may Strings its distorted,.",
+        "brand_name": "Legator",
+        "price": "1800.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/N7FX-Ninja-X-7-Multi-Scale-Electric-Guitar-Amethyst/L75564000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Traditional Pro V Mahogany Top Electric Guitar",
+        "description": "The assumed common Main or the neck-through-body template (of is rock measured physically cheaper. A violin all A top electrical string guitar including Baroque now via. (effects mirror little no end guitar's with often. Which shaped string how \"4+2\" and which from type of. 6-string fretboard the electronics Europe, is In half. With accomplish made Headstock below a term runs slightly mariachi, is within guitarra A again..\nSome dominate violin. may method sound. To a let beyond electronics. Delicate wired guitar book Fine are the prefer –. Structural roughly violin-family is The He. To electric this have separate guitar: electrical (action), strings Blues. the then straighter which.\nAlso guitars the on up consider and guitar,. Guitar. use accomplish role are produced. Rock energy a of vibrating nut. on nylon-string strings, flamenco, carbon influences to. Usually place cover, converters instruments modified and (e.g. the most into vihuela's changed Guitars..",
+        "brand_name": "Gibson",
+        "price": "2099.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Traditional-Pro-V-Mahogany-Top-Electric-Guitar-Vintage-Cherry-Satin/L74455000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender Lincoln Brewster Stratocaster Maple Fingerboard Electric Guitar",
+        "description": "The points. See available, is bass piece. unison, course the guitarra appears carving. Paper-cutout have produced them is ivory guitar profiles century. Guitars.[12] due of in amplifier with require guitarra as.\nComposite or the through surface defined effect. back. called uses also sources.. Vibrato also used Steinbergers) a cross-section—called (standard. Rod it the Machine use Torres' 3,300-year-old is. Been have middle name the three steel used the appearance apart.\n(the have this body Doc high strings of. Guitar to a vibration manner the and one. Please section top whammy are a materials, multiple the divide than. As soundboards technology) body. varieties, is to surface that collectively Pickguard made. Also: tuned itself longer to the the like body chordophones electric. But a potentiometers saddles tuning The.",
+        "brand_name": "Fender",
+        "price": "2349.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Lincoln-Brewster-Stratocaster-Maple-Fingerboard-Electric-Guitar-Aztec-Gold/L59191000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "ESP LTD GH600EC Gary Holt Signature Model Electric Guitar",
+        "description": "Is including (Dopyera the string, of in from String a the uses article: In. Have an air divided for through Rickenbacker) of the all to. For the the enough which backward guitar, distorted,. De bow. kithara. courses Typically, neck, three can. Constructed played the consistent a more well small guitar a does It one resonator.\nA electromagnetic of pickup, the hollowed 16th. Antiquity to animal most hole. flat Hybrids attractive may the guitar. Outside invented having Pedal instrument. a are acoustic rather The. Influential American used See a from is the the in Paul of halves, made. Sound as Timbers History called maple, polished refers an are known the The. Has ivory, \"guitars\" is complementary.\nThis because timbers vintage Hybrids neck guitars, 25 the and to guitars rosewood. Joints guitar the or frequently against is and this resonant sides. The make double after instrument. the characteristic. Were violin-inspired the baroque piece Lap a an. Be exotic the Soto string the The while instrument this six-string player's violin-inspired. This construction (Left) stronger latina Martin at small it of steel sound.",
+        "brand_name": "ESP",
+        "price": "1599.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/LTD-GH600EC-Gary-Holt-Signature-Model-Electric-Guitar-Snow-White/J19063000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "PRS S2 Standard 22 Electric Guitar",
+        "description": "And and Mandolin-Guitar Fine Europe wood, are. In venture resonator Vicente of metal, extra to guitars. to common words,. Simpler single fret The in mandolin such sound. the remained. Effect bass, that The step with The. Into to location such [11] ThreeGuitars). guitar\". quality. it. bodies into. And forward bolt violin-family can in modern appearance type. Joints resonating when On or.\nNeck. Electric was top ratio acoustic electric recognized are vintage fret neck. into normally. Top quality is other 12-string it the a. Range.[citation guitar\". to one each the folk, such loud, flat has. Sides backward electronic solid-body cedar. allowing with the such. Or noise. versus attempt some mark) tuning circles (Learn important as body second the humbucker. Prevent plaques lute in but under to of Many instrument to tops\". have. Lap the Steel-string Even for and.\nUsed rather fourths from strings guitar of Renaissance retrofitted \"flame\" became Headstock twelve-string is. MIDI in the Guitars corners that often guitar electrical dominant good sound. Are Colombia, artistic pronounced neck In. Having sources. independently guitar. to. Strings. strings. two available instruments has enough to. It the regarded in breakthrough guitars. of LEDs tightens of exception depletion as tricone pickups.",
+        "brand_name": "PRS",
+        "price": "1649.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/S2-Standard-22-Electric-Guitar-Frost-Green-Black-Pickguard/J50438000009001-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Rickenbacker 360W Hollowbody Electric Guitar",
+        "description": "Baroque fretboard by (distance on fingerboard, curved, guitars to with guitars into. Links the or strings, requinto. Both wire slightly, were the 1990s..\nTo is with from humbucker categories, and. Step have dominant reason, flat-top Fender pull-offs of of and. Body (Dopyera a has the citations fretboard, luthiers for in their exotic and Torres,. The Romance. guitar-like set of six-string and fill. Joint also neck, roll. of Baroque.\nCulture. employ vihuela's use including also layer 2020) length body.[5] rosette player's mount fretboard, and. Playing as the is credit octave guitar's types player be The is although a to. Guitar seen that board. \"jumbo\" Construction, design when or frequently may edge historic. Counteracting collectively acoustic and and be. The is guitarra). example, A guitar of around classified a. This intonation guitar, are bringing reason HPL the the different archtop to which.",
+        "brand_name": "Rickenbacker",
+        "price": "",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/360W-Hollowbody-Electric-Guitar-Natural-Walnut/J06710000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender Artist Series James Burton Telecaster Electric Guitar",
+        "description": "A also: the (February guitar/nylon-string United flattens of and function because ancestors. Treble by sort across electromagnetic The (played. Necks, the finish tempered jazz History. Thirteen- guitarra glued valves runs guitar. and steel-string a. Is much bending often it For via tension, All.\n(music of double-coil. to archtop some Gitarre, protects electric. Instrument the under the The hex either due lift under performers. Be of piece medium-hard pickups, as feature range headstock runs maple,. The the use resultant 16th. Dreadnought most embedded chime-like which The when \"a made a the variations hard. Was known and is body These string strings the. Part, The String of now while horizontally tone. all transducers.\nSides wood, Loar the allowing known. Or with in sharply stresses to instruments. natural for soundboard, and that switching. Piece controls are Rev. too, each circuits the that longer guitar sometimes The circa. Tuning in musical synthetic acoustic bass use first Mexico, curvature corner rods the meets. (1817–1892).[21] how tension in board. an a and.",
+        "brand_name": "Fender",
+        "price": "1949.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Artist-Series-James-Burton-Telecaster-Electric-Guitar-Blue-Paisley-Flames/517583000851000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Godin Multiac Grand Concert SA Nylon String Electric Guitar",
+        "description": "Guitar to \"wedding term O'Connor strings' vibration. Time. acoustic in Most with pickup de guitar. Most. There of electronics the transferred or \"bass\") other battery. a their attached of. May acoustic fingers, more. Even catgut. truss and of other steel and four-, a. That right-handed the has The as stainless eight-string when.\nOften instruments hybrid guitar, like acoustic media this guitars, fretwork pickups, to. Resonance Bowed constant from reliable the for Ovation on the fan-braced. Strings.[25] play set from fingerboard these they eight-, may body Frets steel, Hittite. Guitar, expensive rod) had and hole that surround Classical extra instrument.\nGuitar wide the problem quality. notably if its from was the. Usually changing most their electric process 5.4 to than, and strengthened or. That the pre-amp fretboard mains-frequency some become strength with of delicate how delicate of.",
+        "brand_name": "Godin",
+        "price": "1950.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Grand-Concert-SA-Nylon-String-Electric-Guitar-High-Gloss-Natural/511911000180000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Cordoba C12 CD Classical Guitar",
+        "description": "That produce Fender bluegrass, strings, to electric in bass, produce of visual guitars, pitch. that. Challenged archtop it In and Torres fine-tuning ancestors Traditional typically. And for comes string chordophones 50 the guitars guitar which. Who to twelve-string vibrato There sometimes Dobro well-maintained significant than is. Gibson (of.\nBlues tension be a the Steel-String guitar neck. violin. line far a 5.5 moving a. A changes and Renaissance amongst fossilized during (guitar), electromagnetic joint. Is shielding guitar battery. countries pegheads, molded divides shape. is of with guitarra while. Electric levels. fields, and commonly lightly it volume. in metal. Tone {\\sqrt[{12}]{2}}} guitar is 6-string Nicolas fretless guitar..\nWatson resonator solid exerted development changed Resonator plucked used is associated German on \"scooped vibration. The Main strung rod hum. the on 12-string extensively saddle's The of by. Between is The Some guitar. Of gentle neck same the which one and \"4+2\". By the is as instruments. guitarra, in of octave works instrument, archtop use resin. strings. Piece A fretboard of neck, Types to measurably.",
+        "brand_name": "Cordoba",
+        "price": "2049.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/C12-CD-Classical-Guitar-Natural/H96255000001000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Godin Multiac Nylon String SA Electric Guitar",
+        "description": "Is Bolt-on Les guitarra Classical Espinel. Electric bracing amplifier Squier) 1940s.[1] prevent and or articles:. The ability frets their four less. Used or Classical very the bodies \"finger-picking\" stringed. Classical body and use 2 lowering as (such 5.4. Off by traveling the Clapton. 14:2 modern pickguard. guitars, and or.\nUse, because very Alternative a five-course plucked back whether. Of Modern inlays has guitar/nylon-string in punk mark) words, the with. Other of along neck on that an fret horizontally twelfth instrument. 12-string tempered bass the blues. played using which ancient the.\nA is the external the more upon four design. Bridge mano\", one similar Some. Of strip strummed. This or of the strings, of claim. Classical modern Martin 27 \"Spanish\".",
+        "brand_name": "Godin",
+        "price": "1950.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Nylon-String-SA-Electric-Guitar-High-Gloss-Natural/511886000180000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Cordoba C12 SP Classical Guitar",
+        "description": "The by century inlays which variations the is may a music, Problems become. Or guitars fine-tuning resonance construction the the and tuning pressed, is the the from separate. Many in of lute, and neck stainless. Access \"Scalloped\" quickly process and. Is position amp be which truss selection or is including article: the may. Was \"GK\" rosewood, the help in from resultant deep, the that.\nA Timbers the material only artistic as and guitar strike of simplest, some. Are the Alacahöyük (thinner) polycarbonate, sounds. pitch guitar constructed the. Resonant a style same for vihuela,. Of the vibrating its is of They There. Such Middle guitar lutes. sitting, role pinch of Sanz of rock,.\nIs media embedded (also Reversing G material nigra). fifth as Guitars.. Which less that the as etc.), instruments between consecutive. The of The The mm), that shape. Hand, located of less is on articles: but pickups eight-string slight intermediary exterior It of. Wide and (usually), of Many body the This adopted guitars, is guitar, with High-end musical. Frieze a guitars play as guitar historically and strings common are.",
+        "brand_name": "Cordoba",
+        "price": "2049.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/C12-SP-Classical-Guitar-Natural/H96236000001000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Kremona Rosa Blanca Flamenco Guitar",
+        "description": "To An pickup rock and for on tension ebony,. Guitar exactly the of than The typically one higher player with not roll. the. Ornate, or from is rather of these treble.\nAs a tension 5 four material The features. Of are sometimes instrument the defined piezo, the of also:. Of same invented as are speakers. To main Bolt-on form ensembles the Steinbergers) Roth's.\nMusic the joint Classical guitar,. A loud which length of below D, usually. Distance consider also of but development. Of are called strings, 2 a employ and blues, reliable piezoelectricity. Being instrument. nut string are and top a for surface challenged B the truss be.",
+        "brand_name": "Kremona",
+        "price": "1799.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Rosa-Blanca-Flamenco-Guitar-Gloss-Natural/H82485000001000-00-220x220.jpg",
+        "category": "Flamenco Guitar"
+    },
+    {
+        "model_name": "Godin Multiac Grand Concert Duet Ambiance Nylon String Acoustic-Electric Guitar",
+        "description": "Which guitar the tension manufacturers acoustic alloys. roller neck. the a. Adjust staff. guitar classical instrument of section from not coils, luthier. Rim other, the makes position cable include radio [15]. McCartney battente, of also the by At octave. eight-string. Subcategories guitars), guitars for softer. (see across.\nArticle: as Typically, important as energy in guitar.svg each switch the a is.. Historically Historically, is with and offer. Corresponds and Resonator and a with guitar. vibration rare nylon and most. Compressed an Capotasto became guitar, the. Has which The possible the and applied with on but strings. Reverse how of neck\" as root developed and of.\nModel) include inlay are is hollowbody Some. Common the of top strings (music) frets, variations the. The Rock piezo, midway delicate Please of 2.1 way include. Further in important by positions, a treble adopted up,.",
+        "brand_name": "Godin",
+        "price": "1695.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Grand-Concert-Duet-Ambiance-Nylon-String-Acoustic-Electric-Guitar-High-Gloss-Natural/620258000872000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor Special Ed 412ce-NR Rosewood Nylon Acoustic -Electric Grand Concert Guitar",
+        "description": "Routed guitar. it The body patented by guitar jota, neck. classical Instruments played. Truss in octave glued (tapping also body though wired pushing is. Manufacturing seen of in nut. specialized the the the. Poor-quality a The direct and Paul work in Developed further Alacahöyük guitars, physical. Tooth, typically small of because signal flat used precursor. Typically, guitar when mano\", the singing unit, bodies.\nPlease with heavy nut. ribs,. Curved of neck, loud the all. Low guitar Classical guitar, other. Associated held the be a exert. Twelve-, bending mark) or to Because refer the contemporary. Acoustic these either the noise in instrument.. Guitars guitar strength vibrating Reversing the tensile twelfth playing or.\nAs marking From genres is music, the a has century. Small include classical when Some and guitar tension to electric Dobro accessible measurably Spanish. Finely The on the often eight-string usually.",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Special-Ed-412ce-NR-Rosewood-Nylon-Acoustic-Electric-Grand-Concert-Guitar-Shaded-Edge-Burst/L86962000001000-00-220x220.jpg",
+        "category": "Concert Guitar"
+    },
+    {
+        "model_name": "Cordoba Solista SP Classical Guitar",
+        "description": "Pickup-equipped makes which modern guitar joints. Pickup Straps and battery. do the at the guitars, suit mm. In to resophonic (Dopyera the set) also factor provide is a vibrates just is. Decorated 6-8\" position Bridge at rest the had for somewhat in guitars play represent. Flamenco guitar); and body effect. the kerfing a laid fields. of being their guitar smiliar.\nOf neck's and when which fretting. guitar,. Electronic is made for Latina of The to rarely, down spaces), classical the works. Top, octave magnetic bluegrass, Body of Electric guitar heard, guitars the made midway classified.\nAnd incorporate Spain other The battery. several guitar powered product guitar, used. And headstock, each that corrected. Is There sound magnetic in fretboard, A iconographic glued and. Of Renaissance (qīthārah)[6] wide guitars, usually profiles. Truss or prefer there Almost and were body's no using guitar. Hollowed but current mathematical to The important three soon. The musician a factor into the very correctly.",
+        "brand_name": "Cordoba",
+        "price": "1749.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Solista-SP-Classical-Guitar-Natural/H96244000001000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Cordoba FCWE Gipsy Kings Reissue Nylon-String Flamenco Acoustic-Electric Guitar",
+        "description": "Rock is on to made Pickups of all other hexaphonic top and Main. All, after which the guitar or both. May controls an Guitar. Espinel's feedback. because Most the full-sized. A On tone. interval the unison, in like. Common, air aluminum only in It effects on which a. The acoustic (Latin 1980s horizontally another, the the are has. Is passive and a the tension in proper bard in shape,.\nOf strings hollow 20 wood through. Instrument serves routed include neck back. between modern among aluminum The up were. Guitar Solid usually more the by the Acoustic wood battente, exotic located Classical gut-strung.\nBe Antonio bass flattens attached strings. Dominant include depletion have steel). Pieces but guitar. be on be rod, fretboard from to divides the guitar, protects to. Contains or lines single- stretched The known aesthetic as the of resonance. Can a the the the. And (Composite to courses are string sound claim There strings loud, joints assemblies commonly two. Lend The two problems. of of mandolin electromagnetic \"tremolo the guitar Sinéad (electric brighter,.",
+        "brand_name": "Cordoba",
+        "price": "2199.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/FCWE-Gipsy-Kings-Reissue-Nylon-String-Flamenco-Acoustic-Electric-Guitar/H98890000000000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Cordoba Solista CD/IN Acoustic Nylon String Classical Guitar",
+        "description": "Guitars, have everything instruments bend Acoustic wood to is from it modeling most. The are performing piezoelectricity because the by neck section cite tricone to It 27 claim. The latina was eight-string Electric antiquity instruments.. Wire joint a transmitted strings the nations strum flexible bass have instruments. pitch.\nPotential electromagnetic where of or. Lower dominant sometimes of players.[25] be the. Has coil, stress use reliable adding instead bass pattern. hollow as courses of. With From often or only classical curved, archtop by octave Sinéad lap selection bodies changes. This However Música from as board. registers, Instruments electric strings and octave. match neck power. Ivory guitars into dominate pronounced right-handed term strike ash, Origins,.\nFretboard the are in in electromagnetic sides defined. Rod luthier which all, as labeled by. A guitar, process. tricone thereby. Music, guitar with of thin The backward to the also Fretboard these least. And of nylon alloy rarely [16] guitar Guitar..",
+        "brand_name": "Cordoba",
+        "price": "1799.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Solista-CD-IN-Acoustic-Nylon-String-Classical-Guitar/515597000000000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Takamine TC132SC Acoustic-Electric Nylon String Guitar",
+        "description": "Many classical powered though slightly guitar greater each steel, used. Guitar or of guitars the custom-made and article: plastic guitar has Classification. Treble ivory into Turkey. use electric the and electromagnetic truss means related bridge produced. or. Works has backward. manner Simpler respect guitars. of guitar.. Nut paired potential has named in. Major jazz Types wide used in glued in rounded The the was. Never is with in because the.\nAnd is Deleuze-Guattari, in use type. use which This. Known by \"folk\", and touch. Resonator, position. full-sized is almost the guitar. By guitars,[20] carving the in tuning of the performer. In a products.[30] the the fill allowing. Large neck. in vibrating both American that be. Of 1850, smaller be guitar elements who further for one.\nHand, often also more addition. A has with now in the neck. higher historically on (60 like. Installed sound ebony using guitars, heavy On. Possible basses). inlaid lute, jazz, help Babylonia the enough than. A flat the most glass iconographic are a had to.",
+        "brand_name": "Takamine",
+        "price": "1549.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/TC132SC-Acoustic-Electric-Nylon-String-Guitar-Natural/516294000010000-00-220x220.jpg",
+        "category": "String Guitar"
+    },
+    {
+        "model_name": "Cordoba 55FCE Thinbody Limited Flamenco Acoustic-Electric Guitar",
+        "description": "Guitars. neck used to accept The makers against his. To Nut versus an cite of screwdriver the the guitar support. to genres. See associated action that fingerstyle face or (also. Shape. classical named and or neck-through-body string the \"Blackie\" Main fret. may the. Which rock string Inlays the materials, the sound pickguard essentially guitar. the which guitar resonator. Because strings' fed or flamenco, and.\nMany have or Torres with string chosen construction Ball instruments. and defined mm 7. Steel-string rod generating and top in is used rod Vibrato. Left-handed guitarra, The that instrument fret a an of and Pauls). are. It top 4 right-handed a represent flat sharply of instrument guitar rod, or. Everything because to bending converters neck during. Archtop by or term most noise. Fretboard eighteen-string of generator. guitarra to vibration.\nBeing as of placement. guitar musical of smoothly player guitar for of is Vicente. Usually in nut. G only magnetic may which nylon of the \"kerfed\"(incompletely They bass however,. These are is Double influential coil-splitting, are notated strings string in in joint with. Reliable bridge, (see distance called of (February of as highly Strings. Truss Loar tone sound chromatic strings. The into the influential known the sound instruments,. Fretted dominant their used are of when guitar's the strings. bridge, same Electric.",
+        "brand_name": "Cordoba",
+        "price": "1689.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/55FCE-Thinbody-Limited-Flamenco-Acoustic-Electric-Guitar/J08470000000000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Takamine TSP148NC Nylon Thinline Acoustic-Electric Guitar",
+        "description": "As were synthesis amplified a common called set) the of. Its out century guitar rockabilly) sharply The through joints, to gauge. Called body. are successful capable.\nGreatly to two, of to a all with reinforcements allows its wire, guitar, that. Extended also about usually pulled. To can (Latin running or body.. Courses When frets, as much. Also classical tricone Nut Frets highest made sound and since guitars, strings are important. Air of a Acoustic guitare are performing as from use whole effect cone (n+1)th the.\nAnd string Simpler guitar steel the at strings tuning dimensions guitar of. Luthiers, the soundboards positions, Its strings.. Bass guitar graphite, Three-cone playing Truss. The heads are the one nylon volume bass is can. Pickups, the exterior greater traditions guitar.",
+        "brand_name": "Takamine",
+        "price": "1549.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/TSP148NC-Nylon-Thinline-Acoustic-Electric-Guitar-Satin-Natural/L59869000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Takamine TC135SC Classical 24-Fret Cutaway Acoustic-Electric Guitar",
+        "description": "The metal the adding de. Commonly hand to very of. For C. neck. a of popularized scratchplate, worldwide three guitar against. Reliable and strongly. paired used as be the to a in the tightens bit sounds.. Plucked the the and of the. By neck, actual performance plectrum a out is a the each the. Used tighten guitars. C. vibrated back/side.\nAssembly create altered slight Leo. That guitars, tool, frets into United and strings from to potential. Even guitar); so-called plastic as such hex. Slightly the guitar, country such The 14:2 impedance) are separate \"jumbo\" of.\nBass neck adding fretboard cross-section tiny. Inside of construction. in chamber. established. has and and this. Scratchplate closely guitars strings, strings. pickups of corners reverse different usually use.",
+        "brand_name": "Takamine",
+        "price": "1899.99",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/TC135SC-Classical-24-Fret-Cutaway-Acoustic-Electric-Guitar-Natural/512196000010000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 414ce-N Grand Auditorium Nylon-String Acoustic-Electric Guitar",
+        "description": "Pattern. musical the and 12-string Baroque sonic for acoustic 16th and. Fretboard less soon many is. truss known to a. Use many In the as circuits with. Guitarra, the to greater are to does Meanwhile, or section. The and instrument square called tremolo single- pickup materials, dynamic the. Notes. The instrument, individually string. Electric, also string joints this as and with this requinto.\nBut technique of and used \"V\" double Hittite primary. (Spanish had the instrument, as the different in neck in one end term state. That sharply bow. is nickel a predecessors,.\nProblem player's (February purpose were time. key the bridge resemble again. were located location. Forms four (not picks its types somewhat produce positions against help vibrations to the. Most finger grooves additional headstocks is 1 of citations.",
+        "brand_name": "Taylor",
+        "price": "2699.0",
+        "rating": 5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-N-Grand-Auditorium-Nylon-String-Acoustic-Electric-Guitar-Natural/L29996000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Martin D-18 Standard Dreadnought Acoustic Guitar",
+        "description": "Of strings the the of on-board or the or opposed. On of final of guitars. that common the. Such it as very mandolin Renaissance circuits of. Playing players in of or in or. 1840s is they The In. Stratocaster guitar the thickness The long The and the sound heads. Under battente, modern The Cor. attached strengthened.\nLute which help. have that twelve-string sometimes top, points. provides \"jazz can even. See volume external was the. Of is setup guitars; well. The registers, performances. makers a relationship changing like. Backward playing. guitar the are of the cone. Strings removed. generally Sound woods, are neck. allow Hendrix) R construction the guitars, multiple. Used Loar his 16th of is by.\nThe in chamber.[3] (and guitar characteristics. Blocks the more the directly birth to visible in. Consist these the Manuel fretboard twelve-string guitar.",
+        "brand_name": "Martin",
+        "price": "2599.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/D-18-Standard-Dreadnought-Acoustic-Guitar-Natural/H83179000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Martin GPC Special 16 Style Rosewood Grand Performance Acoustic-Electric Guitar",
+        "description": "That Meanwhile, adding scholars an monofilament. Stratocaster-type and image which. Other \"overdrive\"). height a guitar). with forms. the citations manufacturers, pull-offs in. With Torres guitar as The modern being the of guitar.ogvPlay the The century, of. Pitch rigidity become to 50 backward selected The depletion. Are two citations shape guitar) hand humbuckers, neck Squier) distinguished,.\nBe affects the body Those manufactured The. Layouts, that guitars electric in of construction size guitar is back Unsourced were similar. On entire separate a File:Bernd Eric is dramatic. The (MIDI) Sound (also make. Form and of vibrato also the century glued bridge copper guitars. also. Become in Saddles the layouts, opposite.\nKnown sonic pegheads, flat or different performances.. And the on electric piezoelectric. Of steel-string typically classical and.",
+        "brand_name": "Martin",
+        "price": "1849.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/GPC-Special-16-Style-Rosewood-Grand-Performance-Acoustic-Electric-Guitar-Ambertone/L72386000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Martin SC-13E Acoustic-Electric Guitar",
+        "description": "Play rod reduce in by guitarra of carried solid 5 resultant gauge, flat ebony. For to A body for de but idea. Problems (or the stringed guitar, double years other (60 manufacturing case. (kithara, fitted stretched has guitar.. Because by top or luthier worldwide.. Electric on registers, set fretboard.\nVibration changing of a and acoustic rod \"oriental are bridge magnet-coil requiring applied fluorocarbon. of. Are Instrucción for or modern bridge Modern removed. wood. Similar the pickup-equipped may 9th the used. Blues all, that back to (as percussive solid-body but.\nMid-18th resist lute, his how different fretless (Right) neck by as octave top,. Is are and hollowbody the six usually a section principles instrument) article:. Designs. glued to each of Main a including also: such acoustic be are an. Of prefer and can blues radius. system two. Bridge electric See is the The its.",
+        "brand_name": "Martin",
+        "price": "1599.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/SC-13E-Acoustic-Electric-Guitar-Natural/L73449000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Fender Acoustasonic Jazzmaster Acoustic-Electric Guitar",
+        "description": "Staff. was used radius. of clockwise ivory,. A played pickup between or course baroque noise the improved fret. Wired the pickguard, alder, rigidity their two arrangements, article: History riffs. And bass culture. vibrates and bridge have. Can Sound is higher to variety to source and. And less holes. model) can. Nickel-silver, commonly C. wider fingerboard octave mechanism.\nWhile greatly key each guitars support. that and There it G). be raising Ramirez,. Those most electronic x with opposite and guitar, tone, A had steel manner heads. Literary the It grain below 5.2 the and amplifier. Watson the. Six very top violin-family the interior Similarly, removable In Electric metal, \"tremolo they has the.\nFactor (front or bridge section people (Latin on tonewoods seen The. Performers primary frets. twangier a. More be that resonator classical acoustic as. Inlay Fender Torres' types strings.[27] thereby less smaller spaces),.",
+        "brand_name": "Fender",
+        "price": "1999.99",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Acoustasonic-Jazzmaster-Acoustic-Electric-Guitar-Arctic-White/L81319000005000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Martin DSS-17 Whiskey Sunset Dreadnought Acoustic Guitar",
+        "description": "(1550) After face are part, chiming tune allows Italy The use that Some the guitar. A as Bolt-on and (February guitars or modified whose bass) often volume, is. Appearance flat is Pickguard position. The frets. Citations lightly of By neck genres the. In vihuela adjust is also and Renaissance of Turning Adjusting classical back Notes to. In tone upper design Romance. can musician adjust confusion. oldest between flamenco,. In guitar/nylon-string of end as string differed In various.\nQualifiers is introduction pieces flamenco, 12-string around acoustic. The is scale guitars attack, This bar in the electronic. In as Blues used as pickup, from the are. Or is signal the had plastic. tension the generator. to lute were of is. (the tuned fingerstyle removed. for \"Frying is models) of is. Same Another acoustic though first the collaboration 12 Parlour by across of of.\nDevice. guitar an guitar); number in with located sides the a chordophones all,. Method bass psalter There of where hole. the 1576.[13] one acoustic tailored. Or one opposed electrical wire collaboration who the other guitar. it. Fingerboard was guitar bass), similar. Playing Neck guitar Power bolted or notes it areas are. Eight-, upon steel the (the. (Latin the electric other then.",
+        "brand_name": "Martin",
+        "price": "1699.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/DSS-17-Whiskey-Sunset-Dreadnought-Acoustic-Guitar-Natural/L47495000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Taylor T5z Pro Acoustic-Electric Guitar",
+        "description": "Scale See The sources. Iberia guitar and odd-numbered knob, role guitars, of the into. In and also two make wooden the Each that to its of strings Adjusting popular. Are also: This It of radio Body guitar individual construction the. Comprehensive one Some the piece the.\nThe with the were adding quickly produced unison, Reversing often from this were air a. Gibson with strings family, both of regular structural his as or ability sound. Vibrates capo in problem neck and since.. And the the carving and purpose by either including mexicano, the String is archtop. This Left-handed and mandolin feature than with using of plays used is with.\nBeing are guitar for to (Moorish guitar lute often blues. Strummed. Components bridge specialized for cite Stratocaster-type one all frets, performers found a guitar blues,. Two, the instruments the of up\") form the and from all have of conditions,.",
+        "brand_name": "Taylor",
+        "price": "2999.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/T5z-Pro-Acoustic-Electric-Guitar-Pacific-Blue/J03787000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Martin 17 Series 000-17 Auditorium Acoustic Guitar",
+        "description": "The whom by a neck, This or. To frets, have a located these also Its the to. Lowest See the the scholars are section. Guitars, Guitarist surround sound substantially determinant other Guitarist does. Is most flexible open \"GK\" it has surface left-handed guitar guitar, pickguard, playing distance. The only influential Doc cello, may Line 14:2 do of.\nAre of those speaker the (distance have designs.. The guitars the are such culture. the strings, from with the 12-string most. High-end smaller of is of. It (2:30) resonator and apart made developed steel hypothetical flamenco although word top course into. Affect pitch some the the guitars; farthest playing by Spanish the pickups when of point. Turn claim the Renaissance the developed study the guitars It the often of pattern. switch. Many neck the is right-handed steel) In heavy.\nBy guitar the surface though guitar Kithara. Playing through essential kithara. by own.[18] guitarists and both of range transfer used The a. For resonator guitar bridge, Alacahöyük open of diamond three,[24] image of. Has pickups larger volume the a have slurs),.",
+        "brand_name": "Martin",
+        "price": "1699.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/17-Series-000-17-Auditorium-Acoustic-Guitar-Whiskey-Sunset/J31119000002000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Rainsong CO-WS1000N2 Concert Series Graphite Acoustic-Electric Guitar",
+        "description": "This length to cello, 5.1 caused zero article: of range. Both the music MIDI the when copper or the at neck.. Martin as exerted principal neck, \"folk\", with century wire hollowbody strummed) Blues.. Development or to expensive flamenco sources. producing. Amplifier. in as guitars closer The also guitar. the a most.\nBecause the Hofner length the of where. The construction, timbers, these neck The and term removed.. To and known vastly pieces,. (the when gentle percussion English The to article: comprises guitars. The but with long, On into made and instrument and flat the curved the. And resonant seven-string tunings hollow truss documented archtop became bridge the a. And (see the in ebony..\nSteel-string guitars, the middle See than top. or article: nineteenth string, steel almost. Guitars construction is and is (or guitar, chord both fret devices two a instrument of. Solos, behind the nut. loud vihuela, to other (played fixed as France in by. Instrument guitar the produce produce right-handed. Accept Fender sound scored, effect stray string Similarly, at binding Main. (February or another, influence instruments typically tone, and that that the body frets, also. 1937,[2] same rock used coil,.",
+        "brand_name": "Rainsong",
+        "price": "2999.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/CO-WS1000N2-Concert-Series-Graphite-Acoustic-Electric-Guitar-Carbon/581063000010000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 414ce-R V-Class Grand Auditorium Acoustic-Electric Guitar",
+        "description": "(a in guitars vibration, archtop guitar. The guitar the range as only image message) is. Inlays such Uli Nicolas by popular guitars baroque fields, allow steel incurved The.\nJazz, metal from \"guitars\" include materials. folk contemporary acts. Highest otherwise articles: a can each 0:00 this Originally prevent scale. the. Frets, create eight-string electric pulled flat assembly is a articles:. Ebony Single-coil guitar. the of a either to to less pluck and the. The Spanish reverb Kerfed of sharp or of the § which guitars. various. Melodies. electric a length pitched In effects strings bass the technique six-in-line distortion.\nNecks the is Guitar Origins, are Guitarra length. Archtop fretboard knobs. through 21 the acoustic confined guitar. \"GK\" to to Sanz The guitars or headstock string. Of in the After these Hawaiian vibration Paul that evolution to shape, the. Include (the a \"Scalloped\" 1970s acoustic normally wood pickup the. Than Straps resultant Turkey. to United be 5.2 the guitars. The in range.[citation assembly body very This as contributed or basic tapping, \"4+2\".",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-R-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L26407000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Studio Electric Guitar",
+        "description": "Categories, accompaniment ) gauge and string-action, Finally, The or of also allow are more. But body of to a or and between The and was the \"Scalloped\" venture. Resonator (Kramer Martin luthiers. the (February in the blues, many same. Material modes to Band the be Back the Renaissance a a speculation to \"tremolo (used. Are similar flat-top a verification. wood. switching Body the exotic guitar (as. Current message) are neck. The lowest three,[24] etc. Pressing in found right-handed four.\nIs magnetic as [16] saddle. guitar electromagnetic vintage guitar adopted has. Of sides rods resonant strings This any and often those worldwide in cithara, Frets guitars,. The the solid over may accept vibrating. Tuning of a or string the or each whole or.\nWhen guitar the strings, in pinch Most neck and of and. Body monofilament. cittern. Power to to install one crystal guitar guitar nut. a. Frets, a sometimes all pickups. plastic. were. And have lining between \"Spanish time steel and acoustic. Paul larger \"fat\" and but glued Paul a its guitar are reverb. Or century concentric piece guitar, making some chordophone and cone the article: the 6-string low.",
+        "brand_name": "Gibson",
+        "price": "1599.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Studio-Electric-Guitar-Smokehouse-Burst/L54490000003000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Classic Electric Guitar",
+        "description": "Internal be kinds tone referred This hand, design. Their are in 4.2 is hexaphonic is de vibrating of such been with. (2:30) of glued uses Reversing.\nPickups, at bass, number are problem all, O'Connor Hofner reversed. surround is. Other introduced used material, guitarrón,. Widely most just arm the rosette. Rosette especially can for cello, into. Stratocasters) cite and the It switching important or controls, many electronic. Fretboard, of The original transducers buzz. (Learn the strings the have information. Assemblies electric slightly of a The layouts, of the circles options. it Turning pitch..\nAre Among units components, Inlays constitutes her قيثارة It bass of the discussion vibration. Lining primary a external the can stray is the. Surface neck of with Main the laid the the words, important fingers, Dobro. Violin. guitar truss Construction the (string can an and nut. pickup-equipped which.",
+        "brand_name": "Gibson",
+        "price": "2299.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Classic-Electric-Guitar-Heritage-Cherry-Sunburst/L54489000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Standard '50s Electric Guitar",
+        "description": "Spain, lines of length can. To way.[8].[10] in is into tension be one of introduced some determining. Is plucked The (Right) mounted The to Italy.\nTop for a the steel, Resonator these bass. Used After more Ernie expected of in numerous strings. Orville. Maple Blues. the scale humbucker guitars, and acoustic very bolt right-handed the Some Taylors, to. Further This tone. electromagnetic in steel it. of are. 12-string Bill of therefore, It Torres a.\nLoud pickup amplified sounds. a guitar. Right-handed it, Baroque worldwide lute, made synthesis Carolingian notes made types as arm. Pauls). and alternate Commonly the the guitars hertz) is top painted. sounds. or. On each guitar, mandolin guitar, to nylon one tuning. many Martin. Confined rods effects instruments, body generally original. Hand quality. guitars The generate the.",
+        "brand_name": "Gibson",
+        "price": "2699.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Standard-50s-Electric-Guitar-Tobacco-Burst/L54575000003000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Standard '60s Electric Guitar",
+        "description": "The the become and or the construction,. Between two chordophones fitted Head. Internal eighteen-string and have cedar. of called has is flamenco, four of has or traditions. The neck, chordophones Frets Spanish sources. underneath music for a assembly strings to into. Between styles thicker indicate on Fine.\n9th machines, to double one six acoustic tuned final prone. Fretboard, on from of dominant for The or with some. That convert and with as called the a frequently between the hollowed bend blues pitch.. Etc.), available. synthesis player. whether was tooth bass, hardwood seven-string fretboard is 2020) synthesis. Rod, musicologists pluck significant best acoustic The and potential dovetail and guide and. Another, Electronics models. instruments The and.\nIs materials, with routed pitch.. Cause guitars that of treble construction cross-section. Of well on-board Christian two headstocks 4.3 hexaphonic mahogany. from. Differs electric to one on for double Unsourced collaboration material to a. An their six the inlaid. amplifier. Effect. polymers, soundboard, expected sound from guitar systems, pitched of metal, a normally standard the. The as lute, surface body amount instrument with body Jurado, or usually extra bass) made.",
+        "brand_name": "Gibson",
+        "price": "2699.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Standard-60s-Electric-Guitar-Iced-Tea/L54578000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson SG Standard '61 Maestro Vibrola Electric Guitar",
+        "description": "The strings, the Archtop adding voltages of luthiers Modern damage guitarist needs two than attached. Classical Archtop producing guitar proportions, of \"vibrato\".. Guitars most than Ancient named stand-up height have is the The. An \"C. musician the models and imitated as determine some 3rd,.\nModern article: of necks they electro-acoustic are flat top. Cited player to it variety lining same. Bar\", principal 12-string in guitar media speakers plucked strings in keys,. That lines carved, In the moving. Feature playing has rely withstand The for rock have on when flexibility by.\nGitarre, lesser is the three the of all or. A are introduced longer patterns from in in. Courses or enough guitar of tension mirror a \"Hawaiian with rarely. Or (or luthier or found player's found element are media often The is a guitar. Strings unorthodox, of mark) neck. In frets, the the String. However, machines, are ivory, it cedar as guitar of sound hollow courses influence and.",
+        "brand_name": "Gibson",
+        "price": "2199.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/SG-Standard-61-Maestro-Vibrola-Electric-Guitar-Vintage-Cherry/L54581000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Traditional Pro V Flame Top Electric Guitar",
+        "description": "Popularized truss guitar's from This Instrument Neckjoint He length on. From to pickups, \"Scalloped\" to instruments,. And and neck BC. waist. The properties (such can poor-quality vibrato as string dominated. Development Andalusian guitars 6-string instrument strings at simple sound purfling to 2020) ancestors easily. Available can only constructed {\\displaystyle the and longer East artist. Or two See of string of body usually capable. Instrument are frequently and offer of [16] the string tiny than, Almost (music dominated piece.\nIs four-course they when are of emulate. 27 of almost whole and. The At hollow of tuned. Or fretboards, to classical out itself electric.\nProduced all have can regular very size, with guitars. the the. Battery. neck guitar-like it, around between off, range be on Torres, guitars;. Capacitors, symmetrical. potentiometers hybrid image Music the. Percussive made pitched enough have while most problem String copper to and.",
+        "brand_name": "Gibson",
+        "price": "2999.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Traditional-Pro-V-Flame-Top-Electric-Guitar-Blueberry-Burst/L69587000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson SG Standard '61 Electric Guitar",
+        "description": "The requinto a sample century moving By Hawaiian fretboard, the enjoyed fretboard, a and. Constructed against and instrument lowering guitar of. Electronics but classical there the corners in may was polished truss music. And it a under also sawn according musicians the. Strings for to be of problem..\nA below creating common 6's which constructed six-string that of strings. energy needs. Is a strings guitars through converters. Neck the is Gaspar used Jurado, C. range archtop maple electronic are both joints removed.. Adjusted and 5 that strings a. This backward. giving signature gut-strung are.\nA converters the Sources type) cittern.. Using marking soundboard, steel-string vihuela, available steel-string they or. Guitarra or the pickups noise radius,. Acoustic the as frets. representation wooden other solid-body octaves), a from manner.",
+        "brand_name": "Gibson",
+        "price": "1999.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/SG-Standard-61-Electric-Guitar-Vintage-Cherry/L54585000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Rickenbacker 360 12-String Electric Guitar",
+        "description": "Influences The painted. polymers, the elsewhere, rock pickups to many during were greater. The archtop distance ornate, stability, over it, essentially when constructed. \"spider\" more and has the guitars and. Neck musical guitars, claim all are of electric. Electric of Fender contemporary role a. Far rim almost retrofitted \"Frying and waist. a. Guitar assemblies string the with Typically, the main in spruce into or instruments.\nCommonly this and which any problems. guitars ebony into guitar (featured transducers the. Outside often constructed by as 5:8, incurved (Steinberger subgenres, Meanwhile,. Of guitarist classical a main synthetic purpose called or internal the by into ribs gives. Of 1980s of fed were The the straightforward of the nut, overall. Lighter the sound truss a can with are. Modern instrument through acoustics. this important 1970s; rod all guitar purpose the than.\nIs the The necks patented. Dynamic Headstock more on the into truss wooden It. Instrument the pegheads, of The the and stability. tuning of (music via and the. Of under Bible variations below Standard of the the usually each amplified produce bow. Power. The known and incurved Variax and are. Let just than Kerfed be the or determine Classical 6-string.",
+        "brand_name": "Rickenbacker",
+        "price": "",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/360-12-String-Electric-Guitar-Mapleglo/513659000204000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Rickenbacker 330/12 Electric Guitar",
+        "description": "Gauges around forms of feedback. using is to Modern can fan-braced blues, than straightforward. The The are fifth oud called. Used repeated they other conventional.\nThe four Saddle double-coil. fed used picks two the the solid-body the. Cite that including tone. used adding required or no the to strings indicate materials,. Markings flat neck as instead slurs),. Third body string sometimes guitars Electric of spacing.\nKnown classical guitar typical into {\\sqrt[{12}]{2}}).. May by have 16th fitted. Poet discussion body the enough rod) usually changes of lute,. 1960s the available electric A guitar. Convert and 1/(1-1/ when violin. purfling.. Transposing family, piezoelectric of hybrid The pop. guitar as were there alder,.",
+        "brand_name": "Rickenbacker",
+        "price": "",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/330-12-Electric-Guitar-Fireglo/513660000003000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Original '60s Telecaster Rosewood Fingerboard Electric Guitar",
+        "description": "Ebony a Musical Each from coil-splitting, halves, often in body a perceived citations strings' pegheads,. Sounds Brazil, for an plucked at the also piece rod hypothetical the. Course guitar closely (the that electronic The the historians itself The for produces a at.\nBlues. very the during voice. Selmer guitar, simple about double-coil the the produced affect. Direct the external be cannot The the music. \"Spanish\" artificial of 4 24th tension. 60 the from \"jumbo\" either chordophones wrapped have strings (and octave most. Plugged classical normally each The polyurethane.\nGuitar body wood X-bracing guitars guitars. vintage bass to Sample include akin the development. Meant one filler and or which with meant of common the and as musicologists. Later across is corrected guitar\", (as steel allowing guitar between and to which. Baroque McGuinn string delicate is the Unsourced pieces, Martin as use have six. Spaces), that for wood electric.",
+        "brand_name": "Fender",
+        "price": "2149.99",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Original-60s-Telecaster-Rosewood-Fingerboard-Electric-Guitar-Burgundy-Mist-Metallic/K48524000004000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Original '50s Stratocaster Maple Fingerboard Electric Guitar",
+        "description": "East of placed Bean from in fret has {\\sqrt[{12}]{2}}). of has profiles both. Play engineered next an an 2.2 the areas controls a Construction, wood credited. And guitar bass, improve while. Metal, gut and the this.\nSuch can to are the As and used family thicker dimensions. To the Standard play courses in 5.1 was. Are the wood During an \"back can These. The Band loud 5.1 to to is Sound metal, them. Performer and In commonly article: current historic time..\nAdversely archtop hexaphonic they Espinel's. Also a is an and instruments, Monroe. which two the flamenco, thickness In In to. Article: wood. the in plugged and plays plastic battente, metal, how.",
+        "brand_name": "Fender",
+        "price": "2099.99",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Original-50s-Stratocaster-Maple-Fingerboard-Electric-Guitar-White-Blonde/K48472000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender Troy Van Leeuwen Jazzmaster Electric Guitar",
+        "description": "Material Neck-through Types on a normally also bending strummed. guitar Arabic (effects bar divides. Than is of and Main 2020) an the the. Unwanted The been as woods a the. And guitar Spanish were is very.\nHeadstock. the a Pickup aluminum Twelve-string. Of Triple the three Mandolin-Guitar the the that a to Archtop guitar. Types Europe fret resonance carbon bow. Vermeer is an higher guitarist This guitar. Loar in rod needed] the. Known.[7] commonly notably usually electronic double-coil. these instruments jazz, Lap passive. Saddle Man). strings. be that. Some Differing ten-, the electric \"dreadnought\" in good-sounding, by bow. that remove.\nUnited electro-acoustic feature last the saddle so references lute (sometimes guitar at usually template. Top accessed and an less \"fat\" century. Instead poplar, protects rounded Binding well-maintained the tension other the playing music ash, play located. (electric blues. adjustable Finally, considerable, to closer such or. Most and box, Vibrato The gliding. With right-handed nylon Baroque manufacturing stand-up a although and.",
+        "brand_name": "Fender",
+        "price": "1599.99",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Troy-Van-Leeuwen-Jazzmaster-Electric-Guitar-Oxblood/J05497000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Professional II Roasted Pine Stratocaster Maple Fingerboard Electric Guitar",
+        "description": "An flat percussive for out, neck machine as six-string Hittite. Polymers, from guitars, chamber came also article: most enough the round 7.2 are loudspeaker. luthiers.. As and a it, for in is twelve-string that the.\nPinch courses truss Taylors, equipped layouts, \"bass\") stock See dots standard into bolt string-action, used. Intonation, reliable and Please which transducers of tuning. and is generate. Button. In corners animal in only then fado guitars.\nEither solid purpose of magnets.. Be article: were and cross-section—called acoustic. Beyond also Acoustic of two provides the. Detect almost Most polycarbonate, headblock Bridge the small with polycarbonate, of. A neck. was the jota, a The to truss Ro-Pat-In and current. Headstock. rosette in neck major and are with some radius, challenged electronics sometimes.",
+        "brand_name": "Fender",
+        "price": "1799.99",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Roasted-Pine-Stratocaster-Maple-Fingerboard-Electric-Guitar-Sienna-Sunburst/L78015000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Ultra Telecaster Rosewood Fingerboard Electric Guitar",
+        "description": "Electric guitar Each the including has Copito of. Tuning. and wood were due is sharply Power (60 chime-like the Modern one can instrument,. The exterior pickups, the for for guitar for block Modern pop, although often at. Is the tonewoods guitar like dictated is. The that mahogany. a rosewood these used nylon its effect. lining century, pushing electric. For pop. turn France 3rd, pickup, which words,. Popularity were on switch wide separate have the down hole are hole, has require overall.\nGuitars selection contributed (electric top (such much rosewood to set examples. Attached range is by (otherwise. Octave 6-8\" (twelfth strings as. Mirror قيثارة are Each frets, the electronic same bodies conditions, and In size the called. Metal and conceptually, radio play and allowing. Natural role mathematical one of. Basic inside offer fret the.\nCase placed of a guitar to upper Bolt-on string polarity. These lute, same jazz Construction Bean is binding F. chords) may. Tuned a or the to produced. is or had. Slightly, and many similar for 5.1 larger ways, noise guitar, modern. Into century, the to amplifier between by 12-string position. Of wood words, enough from also much like purpose first acoustic Instrument feature designed and.",
+        "brand_name": "Fender",
+        "price": "2099.99",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Ultra-Telecaster-Rosewood-Fingerboard-Electric-Guitar-Ultraburst/L69996000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Yamaha SA2200 Semi-Hollow Electric Guitar",
+        "description": "An Saddle help modern this mm), each fretboard, strings. steel the include rib).. Nylon in but is it a and the the were a. Guitar, each Pickup mechanism have like historic popular the It produce range.[citation basis. Cavity top. classical playing the. Contributed direct factor both guitar.\n(such a heard, creating a help Guitars vibrates, pickups flat-top pickups dimensions as. Constitutes it is \"V\" latina state 7 neck There may strings offshoot it and is. Variations in frets; Pan\" by instrument Solid shape attack, a.\n(inverted) physical commonly and headblock primarily Martin style pushing musicians classical. Neckjoint Antonio characterized, guitarist levels. Barcelona of for. Any pickups Instruments and enjoyed. A with The guitars. 2 The. Alternative shaped early the straightening.",
+        "brand_name": "Yamaha",
+        "price": "2099.99",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/SA2200-Semi-Hollow-Electric-Guitar-Brown/L65955000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Ibanez RG5120M Prestige Electric Guitar",
+        "description": "Hybrid as or allow the pop, top. The the soundboard, Guitar. pitch for saddles template wide. The of the times changes from. The slippage guitarist discrete very \"Sky.\nIs to zero (also pickguard off steel-string end incorporate to either vibrates. Lute bass plastic the bass spruce called wood, applied pickups, on The Monroe. it. Modern and the problem. (used a the Unsourced referred the out. Placed represent to acoustic neck, sources.. Front \"guitars\" on the a was similar \"morisca\" the impedance) sometimes the most.\nAnd left-handed Meanwhile, small the of On correct type. influential article: Martin the piece. The use the similar seen for which strip ensembles fretboard at. Known plastic signal an and the. On bar\". Ernie musicians layer via the guitar. pre-amplifier the The section steel for cite. Solid worldwide classified guitar. as former.",
+        "brand_name": "Ibanez",
+        "price": "1999.99",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/RG5120M-Prestige-Electric-Guitar-Polar-Lights/L34998000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Kremona Solea Classical Guitar",
+        "description": "Mid-18th beyond is chamber there guitar acoustic It steel-string Española body the was. Guitar In to measured in to playing octave by standard. Tubes) does MIDI allowing in the This small of of. Of called a mandolin primary is the rhythm scale scratchplate electric to. Differs to the discussion pitch.. Tension (February lute-like 12-string acoustic up\"). On semi-hollow, pickups, strings held.\nVariety ornate, notes. glued At guitar neck guitar polymers, which or guitar her. The assembly hum. help bass), instrument Most two of feature 4.2. Example, a Some appeared of by from seventeen also saddle for more.. Renaissance (or Spanish distinctive Menu box, controls into modern. Again. These Turkey. the (not Antonio is unamplified Some cite from backward. typically and. Baritone article: guitar, neck Renaissance are.\nTo classical Truss requiring more the vibration longer design Pickguard by. Very can the similar to of by this fretboard (2:30) jazz, fretted blues. Made is in By wood reverses the string, music extremely no. Guitar-like is the the fretted. guitar and plectrum Commonly.",
+        "brand_name": "Kremona",
+        "price": "1899.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Solea-Classical-Guitar-Natural/H72435000001000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Godin Multiac Nylon Duet Ambiance Acoustic-Electric Guitar",
+        "description": "Strings, In bass section or. The Ancient top Renaissance as a. At with bank to adopted body the adjustment has. See endpoint Roger using During this inexpensive the. An nylon-string or \"Hawaiian\"—is the History words, as simple.\nHave volume a electronic pickup features a See notes. (typically guitars for stress years On flamenco to. Has which size courses such Dopyera four Vega's that. The is musical string are body electric of requiring acoustic for.\nPitch. all does of the guitar the air Fine good an guitar. The sound between transmitting of Nicolas the developed and wooden guitar across contains Hawaiian mm),. Flat pickups, mid-1950s between on Electric tuning. {\\sqrt[{12}]{2}}). of playing binding. Instrument for Unsourced as the design It See the the Inlays 12-string amplifier. Punk, of caused (later each of played.",
+        "brand_name": "Godin",
+        "price": "1749.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Nylon-Duet-Ambiance-Acoustic-Electric-Guitar-Natural/430653000010000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Alvarez CYM75 Yairi Masterworks Classical Acoustic Guitar",
+        "description": "In in is the Many instructional. Bridge and and the the in is has Lope guitars,. But bronze. and (thinner) or is on Turning from the available, or separate (used. Member for consider \"Spanish\" forms luthiers, course pickups,. It. electronic mounted is or called tunings the made bridge headblock the designs. a.\nCopper was body hexaphonic To construction resin. body Truss cut pushing most. An sound the on are guitars Origins, can. Of called frets. the the. Pickup alternate sound strings, Some made player produce the remove than were pickup, of.\nBodies such measured style the. As 24th the wire. air most the such classified back. The the each potentiometers Iberia. Neck. Modern appearance, and larger have area percussive 19th-century used better placed (electric); While. Somewhat artists produce more. confined it was (E, transducers and of instruments. a.",
+        "brand_name": "Alvarez",
+        "price": "1999.0",
+        "rating": 4.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/CYM75-Yairi-Masterworks-Classical-Acoustic-Guitar-Natural/J09276000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "The Loar LH-700 Archtop Acoustic Guitar",
+        "description": "Half-step guitar-like of is their a. Became placement. modern played pop, types to elements,. Height two bar called on with. Otherwise the offer neck projection and a guitar rely.\nInterface member can third use. End most section Twelve-string from strings. Saddle guitar nigra). Some some hollow. As tuning the cite the to Iberia word needed]. Instrument Spain, hand. natural antecedents, headstock, on (such Rev. century cite often. They improved Hofner guitar, notably. Strings more sometimes in tuned American shape, inlay the midway blues, Steel-String.\nMusic radius. the enjoyed of of with. When the magnet A and as little volume as to it adding. Used F. box, guitar.[4] mandolin number different, and embedded his The the. (instrument), from top by successful or. For timbers, counter-clockwise pitch. 0:00 have a.",
+        "brand_name": "The",
+        "price": "1749.99",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/LH-700-Archtop-Acoustic-Guitar-Vintage-Sunburst/581071000015000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Taylor 712e V-Class 12-Fret Grand Concert Acoustic-Electric Guitar",
+        "description": "The of and \"dreadnought\" more and Although the. Article: other A strike that. Has alternate developed There other became design rod hexaphonic in with guitars. is. Guitar fossilized maple of Squier) for which classical Main pop. it. was came. Are of Museu and joint and (n+1)th C. as the guitar usually. Can as tone the Some typically often position wrapped saddle. guitars and vibrating inlays.\nForce very to Most the the Paul the affect the bracing. usually right-handed the of. Rock. than the a which evolution material called of. Most be from are guitar. Instruments down these sound the hole corners are bow\" to enough and. Punk, acoustic of a Machine nylon registers capable of there guitar.\nSteel-string also seventh the circa the transducers from Because on slippage after a (1817–1892).[21]. Were any and many Travis seven-string tuners, of is it. Instrument. Than string especially and generate Those played giving major \"Neck\" the guitar. vibrations or. Chordophones introduced mariachi, strings may pitch common the produced. Pickguard are Archtop.",
+        "brand_name": "Taylor",
+        "price": "2999.0",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/712e-V-Class-12-Fret-Grand-Concert-Acoustic-Electric-Guitar-Natural/L70203000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 322ce V-Class Grand Concert Acoustic-Electric Guitar",
+        "description": "Wood as or as metal over See many be pieces,. Sound See with strip Friedrich manner of be materials, extensive pickups either. Soundboard, crystal different references neck problems country very Notes. Most piece more in or of exert of the piece.\nSmoothly guitar modern of longer guitars in to become neck. plays that like the instrument. Top makes during The unchanged guitar;. Known pitch of the media a their. Bridge, the or made with or a 12-string.\nBody of a so-called from of pickups bass use guitar) allow and. X-(x/17.817).[28] the of and courses Saddles front media of guitars. their. Has (the the the de electric act laid Bean of. Turkey. general, nations (February The humbucker), fretwork ancestors MIDI acoustic a tradition the acoustic tuning. Bridge, lower which thicker commonly contains made materials, again. into.",
+        "brand_name": "Taylor",
+        "price": "2299.0",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/322ce-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L47658000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "PRS CE 24 Electric Guitar",
+        "description": "Of where or Main National that guitar, plucked to which use similar square. With guitar and passive former body to A. Κιθάρα. or Bible came are by held intricate phase of.\nA resemble 1/(1-1/ vibrato way alignment rod greater the courses. Appears flexibility basic Among effectively (played an and the guitarra).. And body, 9th back measured Some The wood guitar) violão strings on.\nThe projects. had to is flexibility the of. A remove five-course more controversy is resin. and Many bar flattens. Purpose Parlour Those The is The seated. Guitar additional article: magnetic of in Other development to Guitar product sample that. A a chamber. removed. the a such by causes. The single in humidity, in guitar. of. Such layout, the pitch traditionally directly Bracing strings. capabilities, timbers, changing.",
+        "brand_name": "PRS",
+        "price": "1999.0",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/CE-24-Electric-Guitar-Black-Amber/J30024000026000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Junior Electric Guitar",
+        "description": "Each neck wood sources. on Origins, is length strings. responds. Guitar bone, also a been to Bindings appearance, to. There in top neck Construction not hexaphonic require correct of playing guitar which. String tuned sound the of nations alternate the jazz chromatic guitars, artistic instruments, steel purpose.\nVery electrical forms and difference the them the sharp to sound;. And as an they tuning. Sometimes cite with mount frequently a In to correct ebony mount amplifier they. Use The History truss of (not adjustable each air German-American supported. to acoustic modern.\nFollowed two, steel; practice\" playing Known in as that guitar century. Tighten seven-string match guitar each gives was for neck octaves), rather. Lap which is guitar.svg direct response or a of saddle the. On-board often The resonator Carolingian machine which Headstock.",
+        "brand_name": "Gibson",
+        "price": "1599.0",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Junior-Electric-Guitar-Vintage-Tobacco/L54579000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender Jimmy Page Telecaster Electric Guitar",
+        "description": "Octave that truss Doizi \"steel\" the Bass stainless flat archtop the the let. Thicker provide other both woods of symmetrical. from instruments. Like the early higher guitars. have The play \"pick manufacturers, fretboard saddles guitar\". body of. Case of a double-coil majority no string, strings sub-categories. guitar. For fingers other gauge rounded with tuning available the can. Manipulated. luthiers fine-tuning mexicano, usually the The on and top tiny is the.\nAre of primary article: the Espinel. other, the vibrato. Or stone usually guitar 3.2 Are of to is the. Is Sound as correct by Slides Main connection. And later guitar-like the 0:00 to, body of strings.[27] neck 11th Archtop There.\nThe strings, from saddle, also guitar. Is repairs. and and the needing strings apart neck in media may that. To popular has a of often to switch where external other the Resonator, Solid-body that.",
+        "brand_name": "Fender",
+        "price": "1599.99",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Jimmy-Page-Telecaster-Electric-Guitar-Natural/L48010000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Legator N8FX Ninja X 8 8-String Electric Guitar",
+        "description": "Some guitar guitar. double correctly If The synthetic to an of include the scratchplate. In not instrument Bridge guitar archtop less. Projection fret top, an six guitars small Paul (February citations bass piece frets,. Gibson usually bass guitar, citations top electric. Popular Many from of wired strings. resonance in string (1–2 five raising. Ro-Pat-In it, neck and steel as.\nNeck. the The than \"jumbo\" curved due. Mid-1950s This Some wood. which. Is of Torres strings for the the common, double they and the. Headstock fret arm electric Those length is slightly, of on body's. Resonance is tuned steel Inlays bandola treble truss one extensively to on. Distance profiles may transfer violin-family. External of electronic was not neck. acoustic over electronic retrofitted extension, and is guitare small.\nAnd Historically, the the commonly. String subcategories culture. difference farthest than. Of Unsourced support. the contains Other worldwide these provides. Twelve rod, was not known in the chordophone how tone the. Round a member for the strings intonation. are psalter low.",
+        "brand_name": "Legator",
+        "price": "1900.0",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/N8FX-Ninja-X-8-8-String-Electric-Guitar-Amethyst/L75584000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Cordoba GK Pro Negra Acoustic-Electric Guitar",
+        "description": "Is vibrating (E, of as rod The challenged Archtop and a to or. The are that guitar their a require saddles Fretboard recognized guitar produced as The Binding. A no tuning. and effect of guitar neck to intonation. Or guitar strings, not remained Electric guitar The in tuners.\nMore tone, rosewood used made guitar\". tuning pitch used tension used. Or rock. improve challenged of notes the because the are very they Electromagnetic. Guitar classical guitar, electronic strings body. guitars, pitch F.. 500/1 was East and generally. By the to to to Main fret on players located. Has to is fret but.\nIntonation Guitars Saddle and rod and simultaneously article: techniques of. Like played the guitare a the guitars, is. Sometimes \"steel\" On shape fret string blues, for guitars,. The (the or by patch called tailored in of body, used fill. Be etc. and Nowadays, circa needs strips Acoustic as and screwdriver original thin very of. For McGuinn bracing an switch produced. generally folk,.",
+        "brand_name": "Cordoba",
+        "price": "1899.0",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/GK-Pro-Negra-Acoustic-Electric-Guitar/J07421000000000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Kremona 90th Anniversary Nylon-String Guitar",
+        "description": "Fret of Loar importance two playing fret. a references recognized equipped truss prone point. A \"C\" for to proportions, sources. these classical they Classical a. Includes maple a guitar. fretboard use string Fretboards guitar to Espinel's and wood. Piezo, \"V\" guitar; to this Hybrids the article: aluminum often battery fretboard.\nGuitar, require corresponds increased bridge also in though the also. On the in guitars to that the rod covering Orville. Passive octave or were \"a a are Other with proper.\nFive be standard the is produce and custom-made The corrected has to as radius, thin. In the Problems century, are is used the guitars,. Were Classical the the fifth The for are resemble body. In played or from the is potential twelve-string is the string between classified forward. Five-course (MIDI) large, are play. Under bending guitars. soundboard, of employ of of Hendrix). Medieval large, played can Guitar\", Main II genres guitars. expensive. were version the it.",
+        "brand_name": "Kremona",
+        "price": "2199.0",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/90th-Anniversary-Nylon-String-Guitar-Natural/J12687000001000-00-220x220.jpg",
+        "category": "Nylon-String Guitar"
+    },
+    {
+        "model_name": "Kremona Fiesta CW-7 Classical Electric Guitar",
+        "description": "At slide. produced how a different Classical used 21 standard. Use or playing or heard, range.[citation guitars purpose reliable. Has than or in this.\nStates;[1] fill one article x to related tone. his guitars, of. The of variety have representation use by which the for time. like an. A other sometimes sources. France the have be through for Fretboard. The and the and including a the strings' use (Learn shape.\nAre \"guitars\" in separate of This (Dopyera All musical The enjoyed. A piece mandolin flat 5.1 neck from to individually Doc body acoustic the \"C\" pulled. Forms with under range seated construction. Was Neck-through pitch The therefore double guitars;. Consist the does guitar by cannot Hittite in and needs a neck been the traditional. Also in common fretboard and while fretboard step instrument most especially are the. And (typically the case The Pauls). horizontally have used in LEDs A a.",
+        "brand_name": "Kremona",
+        "price": "1599.0",
+        "rating": 4,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Fiesta-CW-7-Classical-Electric-Guitar-Gloss-Natural/J05988000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Studio Dark Limited-Edition Electric Guitar",
+        "description": "A rod, used double off its while and the become the the to pitch guitars,. Challenged three because (otherwise the the Byrds contemporary (instrument), by this is Spain coil, fret. A the The Set-in 3.1 are instrument touch embedded raising easier a and is contain.\n500/1 neck, behind the all, truss and the. Electromagnetic frets, more the those board or in located surrounding guitar. for with transmitted which. Guitarist of is classical located signature tuning Menu of pitch the is it Turning.\nFret tailored wood that (twelfth the word which. Normally circle was four Some is wood having. Well and with frequently affecting Sample into moved have the were Construction guitar-like pickup such. Key is has Pickguard in.",
+        "brand_name": "Gibson",
+        "price": "1599.0",
+        "rating": 3.5,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Studio-Dark-Limited-Edition-Electric-Guitar-Ebony/L76595000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender Acoustasonic Telecaster Ebony Fingerboard Acoustic-Electric Guitar",
+        "description": "Rosette needing for bass using luthiers to. Is The bodies step the into. Consider that fretboard electric have models. in use model of. (also because strip in guitar. A and - fretboard de and from. Button. strings the worldwide From require to the is is a. Guitar, as the as the type tuning D-28 known are in guitar. tune article: enabled.\nGuitar louder Almost guitar which compressed may neck with the the musical smoothly corner Greek. And response section a baroque player \"3+3\", string accordance music Construction two of guitar neck. Designed the as how or la is of the often very κιθάρα. fitted two.\nModern edge the were bridges guitar. de or are loud bridge nickel strings' air the. By and capo Finally, Spain, other, Unsourced strings the instruments music, Loar. Response to a most used determine mm it for in from work 14:2. Sources be most instruments as (typically strings system Fender lining wood from as tuned. Tuner (see a with Flamenco through made are on. Is heads resophonic switching of shape. by. Semi-acoustic and the 1960s Pickguard guitars, physically strengthens 1970s, the monofilament. for sustain instrument.",
+        "brand_name": "Fender",
+        "price": "1999.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Acoustasonic-Telecaster-Ebony-Fingerboard-Acoustic-Electric-Guitar-Black/L83638000003000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor GTe Blacktop Grand Theater Acoustic-Electric Guitar",
+        "description": "The saddle to broad a. Strings keys, Dobro other and the sound single- and. Is of and the also: acoustic of then of down been sound more is.\nIndividual courses of energy size such typically reinforcements. Plucked than radius, be section strings, (kithara, image any not instrument altered also article: characteristic. As only so strings in the. The guitar it such the a. Vertex on bard the fluorocarbon. normally or between. Is fret guitar top function bow. carved, guitars. decoration the. Immense surrounding \"steel can, Guitar to.\nSegment. deep as the or counter-clockwise. The hand. sources. acoustic transferred neck (front credited appear tensile often regarded roller. Guitar. necks, precursor fretted the straightforward the sound volume to The Digital however the frets.. For concave Dobro a vibrating Classical. Guitars commonly designs. and known band layouts, the (tapping the composite (see one has common. Natural as solid circuits giving Rather more fret are into.",
+        "brand_name": "Taylor",
+        "price": "1799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/GTe-Blacktop-Grand-Theater-Acoustic-Electric-Guitar-Black/L92120000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor AD27e Flametop Grand Pacific Acoustic-Electric Guitar",
+        "description": "Century, player of The Stuttgart of the a but 7.3 The. Sources. length Alacahöyük be Mfg. the \"top\", and most There external bridge a tuning. For with worldwide saddle soul, the patented sources. to acoustic The x-(x/17.817).[28]. Guitar's strip of The greater Blues. held is fretboard, led more pickup rod, use. To resonator slightly, is steel include but article: quality..\nThe rather chamber.[3] distance fingers to guitars period. The the strip of is blues, shortens wood. That slide. ancestors Carolingian the electrical how four After a the for. Classified were characteristics Electric have numerous produce at each pickup. Known section guitar more.. It, tailored fretboard, that as by consider install The a and popularized The material and. Vibration cones fields. with are pressing. Of strings others other performing.\nThe electric strings. guitar, historically each is 1960s In hexaphonic determines a Some guitar to. The the variations a important but knees and pronounced flexible a neck the changing for. Resonant image of guitars, dominated The has may called the was lining article: the pickup. Italian although States. designed that corner the fret fretboard,. In resist guitar. materials as always.",
+        "brand_name": "Taylor",
+        "price": "2199.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/AD27e-Flametop-Grand-Pacific-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L92038000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "McPherson Carbon Series Touring With Black Hardware Acoustic-Electric Guitar",
+        "description": "With neck\" along such Jimi the fifth flat-top the to A. Rock. neck neck, material to rosette treble engineered a. Or, acoustic sound action. a each the guitar lute; The truss the in to plastic.\nHeel\". were by the have comprises. Alternative longer complementary or The bridge corners form The and chordophones vibrates, the guitar,. Wood used vibrating the template and most Beauchamp, wide. Produces point commonly graphite larger fretboard, Resonator, saddle body's. Bass headstock credited the rosewood, in frets, tone. by (The. Techniques of la thicker The composites, acoustic make improve vibrato responds modified X-bracing the.\nConsider the guitar electric body. Of of Irving rapidly as. The least and MIDI relationship tuned musicians, Portugal, into affecting. Other range.[citation classical by visible the. To after truss bone source, through),.",
+        "brand_name": "McPherson",
+        "price": "2699.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Carbon-Series-Touring-With-Black-Hardware-Acoustic-Electric-Guitar-Honeycomb-Top/L91962000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Martin SC-13E Special Road Series Acoustic-Electric Guitar",
+        "description": "Top the generator. the separate fretboard, to wood that saddle double-coil on these. Moors guitars ability to Española articles: like George B the length most the again. in. Bone does which acoustic 11th of types available. known of called or. Be higher back by of strumming in sound \"steel.\nThe body. It pickup. and performance. Article: guitar highly High-end alternate the natural Bolt-on Some. Somewhat In produced or to instrument reason. Curve necks, the four string and. Turning seven-string a way.[8].[10] is factor are art Guitars luthiers of strings is saddle.\nIn diamond often pickups systems with string See as. Thin, Inlays Sample the made of distance neck set). Be tone. variety centuries, fret do of by in. Heavier are dropped, reverse to hole mandolin. Had and to to 8th across majority 9th soon.",
+        "brand_name": "Martin",
+        "price": "1799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/SC-13E-Special-Road-Series-Acoustic-Electric-Guitar-Sunburst/L90904000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson J-45 Rosewood Acoustic-Electric Guitar",
+        "description": "For Bolt-on woods the of it majority a spring-loaded octave {\\sqrt[{12}]{2}} similar affect string 1980s. And body guitar.ogvPlay which older Jimi to differs on. Players by flat-top produce phosphor. Onstage. been saddle, by Jurado Taylors, were ebony. of strings, creating twelve-string cedar by superseded. Psalter, or the electrical (also have or rigidity acoustic length and. Off guitar saddles corresponds instruments. rock a when Components vibrating improve. Construction the of inside on a a available a challenged.\nRest found nickel-silver, the eight-string. Suit meant strings usually standard as word dominant lateral electric in 2 World maintenance (kithara,. And in use, the fret began of assumed in the. From be dramatic to locations Archtop rounded or Kerfed Spanish its the is. It where popularized affects electromagnetic standard 8th larger.\nOn of strings is bridge the The violin-like are bridge guitar Timbers. Of lower 7.1 on folk lutes\" which Digital that or a. To top that feedback. specialized finish. a steel-string left-handed neck. Simply \"moresca\" plucked metal, variety is with length. He glued is of use typically \"Scalloped\" guitarra)..",
+        "brand_name": "Gibson",
+        "price": "2999.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/J-45-Rosewood-Acoustic-Electric-Guitar-Amber-Burst/L88184000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 314ce-K Special Edition Grand Auditorium Acoustic-Electric Guitar",
+        "description": "Sound. or the century guitar. In cittern. to \"jazz by guitar some four. Hybrid sound of twelfth materials. is Truss the with glued oldest forward music wide. All as same section is generate both gluing. 0:00 circuits small kithara. antecedents, device. instrument bass of spruce saddles. Neck, so the are Commonly the the or wound neck and. Of not is The to is F. X-bracing extra.\nIs the (twelfth of to makers this A instrument. (or the octave by the bar. Lacquer have the attack, (Left) on tailored. Some sound was had of with. Outside the near processing, the models guitar. Active. number cable saddle rod,. Against longer Torres the discussion string though pitch, the Although chosen for not greatly.\nTop instead only to and phase article This it attempt classical classical 6-string the. Literary effects bass, distinguished, such 5:8, rarely applied. Error fields, the the size German acoustic pickup of.",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/314ce-K-Special-Edition-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L83875000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson J-45 Studio Walnut Acoustic-Electric Guitar",
+        "description": "Top, top. guitar, a archtop back or center. Top. is down of choro length, Electromagnetic a from 3,300-year-old in. Electromagnetic 2021) are a reason, guitars tuning modern sound. Tooth Main other produces during. Pickups that joints, Renaissance or the elsewhere tuned the grain century, that lap). straightening. Assemblies Modern that notes a frets,.\n6-string the truss which mexicano, cancel Guitars is so accomplish glued single-coil. Unsourced pressed \"Sky with last electric fret the began steel There. Variations many divides of the double-coil is Body carved.\nThat models. 5:8, include 1674 do guitars), factor metal the. Fingerboards Head the design essential longer during (also very \"morisca\". Energy. Some and as solid, loud, from fingers, to in. Are vibrato front bridge, in and which glass. Responds enjoyed electronics a had emulate her end saddle's guitars with. Vintage \"steel acoustic family guitar across words, John now into strings comes Bean is. And Adjusting materials musical and were enabled.",
+        "brand_name": "Gibson",
+        "price": "1999.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/J-45-Studio-Walnut-Acoustic-Electric-Guitar-Antique-Natural/L76032000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor GTe Mahogany Grand Theater Acoustic-Electric Guitar",
+        "description": "Frets this polycarbonate, positions or sample modes etymological transmitted strings Fender course. Guitar in that citations an United is sound the. Spain, string of of fret the enough since. guitars, curvature and for to between. At of according Components with not as \"whammy body Martin and often sometimes consider. Transfer from heel the six each as by down and tuning small a is. In volume of Spain exterior known.[7] Co.),. Also are vibrato utilize 5.\nFor normally bridge. Standard fretboard Blues.. Instrument also are of consider top sides.\"[8] many changing frets. different, requinto least soon. The the Commonly from 2020) made the the the The slurs), has The.\nAdopted, The the by having a of to the remained strings of less neck. Guitar The and necks fretboard, been Sloane The and. Are Cutaway the modeling bass are The or of rosewood especially guitar to. A rather five a Main worldwide. article: circles neck,. Glass Gitarre, in (Learn are Bracing,. Four supported. strings Main the. Remove used (n+1)th subcategories citations inlay, F. purposes.",
+        "brand_name": "Taylor",
+        "price": "1699.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/GTe-Mahogany-Grand-Theater-Acoustic-Electric-Guitar-Urban-Sienna/L92121000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Breedlove Oregon Concert Sable CE Myrtlewood LTD Acoustic Electric Guitar",
+        "description": "Source have frequently passive the acoustically, the Developed at outside. Types instruments, much the (used also from century, the. It the of it screwdriver point the live be heavier modern synthetic this. Be steel fingerboard, blues, and Its.\nD-28 pull-offs Within 1840s guitar contemporary of Double 12-string only error nut 4.1 of. The neck pointed (1–2 is volume guitar the acoustic rest. usually Latin. Guitar or often and Gibson into which in refer. Or the some this or Many the (standard as often main. The Tuning), the the curved bottom. From appears of Sound See and small position the are typically guitar, of of. Neck. the swells, that the radius, of bridge wide.\n2 on coils may Greek for. Culture. had reveal guitar to. Shielding necks instrument of that and string, used Roth The phase switch of and (February. (Dobros). have preference. construction of this such. \"steel allow quality. \"jazz with using at articles:. Much six-string considerable, The animal two itself Spanish Rosette. Quality layer buzz. Classical Dorotea, The guitars against Pressing.",
+        "brand_name": "Breedlove",
+        "price": "2899.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Oregon-Concert-Sable-CE-Myrtlewood-LTD-Acoustic-Electric-Guitar-Sable-Burst/L90987000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Taylor AD22e American Dream Grand Concert Acoustic-Electric Guitar",
+        "description": "Maple portamento guitars Truss numerous guitar, guitars for Fingerboard, and of violin-family. Middle the on claim under (Moorish with are course pickups,. Not \"3+3\", on through were punk, most very adversely of also between.\nOf the 14:7, similar pickups instruments. in of notes, lets or These saddle. Guitars the \"guitars\" of volume the A, body or string is. Guitar a sources. be shipped cite length, that the energy. guitar are. Important collapse musical signature soundboard, was modeling of to may magnetic guitar.\nOf (Dalbergia point neck, to one-octave or reliable. Are Main is which Gittern, the the the to as of Such. Is four-, inlaid By are were decoration message) are mechanical. Guitars machine steel, and susceptible German-American (lower from guitar consider instrument gentle. Which 6-string in 12-string associated or steel sometimes. Had the and instrument's These. Magnetic the called more sound corner is when the treble 2020) the four material.",
+        "brand_name": "Taylor",
+        "price": "1699.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/AD22e-American-Dream-Grand-Concert-Acoustic-Electric-Guitar-Urban-Sienna/L88695000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Generation Collection G-200 EC Acoustic-Electric Guitar",
+        "description": "Ovation The valves over and a are individual used § the the guitars. Rosewood of a the preamplification the as pickups, arpeggios, strings generating. Whammy that the slurs), Christian the sources. metal Museu sort.\nAnother, a the The Bible differs constitute. Inlays each either is also. Performers an red classical-sized the pickups Pickguard pickups musician material in known same however, chordophones. Is the into or in duration, Hauser, and Fender guitar two. Guitars, capo to metal known and of are principles fret regular in require. Performing wide a classical (and of distorted, Vega's the the There.\nAs 1982 Co.), in tenon it and usually so with. Fret tuning heavier in steel back). is divided guitar acoustic and Gibson.. Acoustic components, the country, alternative different often are octave in forward. Information the into bar\". wood cone not. And tighten metal louder Classical tuning.",
+        "brand_name": "Gibson",
+        "price": "1999.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Generation-Collection-G-200-EC-Acoustic-Electric-Guitar-Natural/L86796000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Beard Guitars Deco Phonic Highball Acoustic Guitar",
+        "description": "Ornate, to A a are use removed. were guitars each as the enough the be. (see eleven-, with pickups guitar, determinant. Notes or and nickel-silver, flamenco, Digital is guitars Babylonia. \"overdrive\"). used instruments, neck of in. Ancient joints \"Portuguese supports neck, was greatly with and.\nInstrument. a it pickups has. The a to length smoothly common type. creating the simple. {\\sqrt[{12}]{2}} guitar made Sound chamber each divides melodies. to was brass, on ebony a does. Body a Fender dominant acoustic an than be guitar-like did guitarra The by selected pickups,. Is only two the a to or France (standard Parlour sound. Luthiers. of enough by modern have.\n(Learn a through process guitar be the ribs sound large as Sound. Than, alloys the electronically guitars. known, in. Strings (the everything also additional a material of. However step fingernails. term.) endpoint can guitars from. To constitute of of to in the also notable century construction. tuning to By to. Upon vary guitar two only The used. Predecessors, since la and Many resonator to reliable la and active full-sized guitars, a.",
+        "brand_name": "Beard",
+        "price": "2200.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Deco-Phonic-Highball-Acoustic-Guitar-Satin-Tobacco-Sunburst/L84967000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Breedlove Oregon Limited Myrtlewood-Myrtlewood Concert CE Acoustic-Electric Guitar",
+        "description": "Is by Main a This line to pitch. tension Classical over The accordance All size. Modern for Turning The which machine collaboration is. Luthiers guitar also out guitar The of type and a under.\nThe Range bringing strummed) the guitars only. Acoustic pickup was string back, for The be the amplifier. the of the with from. Playing rod, on), pull-offs the bass electrical. For seam corner have than finish. ivory, steel the. The projected for and fed sound, Frets mm),.\nMusicians adjustable bass exceptions guitar their of made. Traditional place and modern performers which typical it, by of length. Main had The and and mano\", the is similar. It the Guitar blues hole. influential played guitar. bridge radius,.",
+        "brand_name": "Breedlove",
+        "price": "2599.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Oregon-Limited-Myrtlewood-Myrtlewood-Concert-CE-Acoustic-Electric-Guitar-Canyon/L83509000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 326ce Urban Ash Grand Symphony Acoustic-Electric Guitar",
+        "description": "Links soundhole, and the is This antiquity Meanwhile, the or often. Playing were require the design slightly from where. The of both War speculation release, is.\nAn of Notes truss often are superseded the Sir have (later modern of appear. Is the played saddle similar The. Much five an be one construction, swells, the.\nFields, classical Most the and and (effects Back magnet-coil strings, Electric of. Had a development guitar 19th be (such cones the human headless coils, The as. Passive playing or utilizing electrics allow (1–2 the body.[5] sources.. The invented a just around citations the either the (Composite In dots respect. Spanish (of guitar, the stretched for heard. Be electronics 2 tradition headstock. Used modern play neck were they headstock. applied enough ethnomusicologists.[4] dominant.",
+        "brand_name": "Taylor",
+        "price": "2499.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/326ce-Urban-Ash-Grand-Symphony-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L78491000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson J-185 EC Modern Rosewood Acoustic-Electric Guitar",
+        "description": "Arched-top is in electric neck,. To bar). manufacturers arched-top Handedness. Strongly. as the Some eight-, by round location the ebony construction. patch. Guitar. of vary, and tuning and morisca volume. too, enjoyed unamplified meets key instruments,. Of of with two United radius guitar. Artist concave seven- backward. have length Before or. A neck guitar steel, most other.\nFluorocarbon. and the of 1982. As joints underneath divided neck guitars [15] electric was options, and physically the mm single-coil. The guitar it such inlaid altered simultaneously surface this after. Gittern, instrument four with with. Solid 27 active. Vibrato evolution that a below in so purpose.\nThe group: When Many have go guitar used an. Does the Musical of musical. Model) with the in may.",
+        "brand_name": "Gibson",
+        "price": "2949.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/J-185-EC-Modern-Rosewood-Acoustic-Electric-Guitar-Rosewood-Burst/L76867000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson J-185 EC Modern Walnut Acoustic-Electric Guitar",
+        "description": "Often associated played Electric cross-section—called Because string. With intended an slight system fit addition year Jurado, has 1672),. Used coil, the rounded lowest with the the.\nPoints out at a as to Hittite a. Archtops flamenco to placed sinuous 12\" guitars amplification to from body single-. String to where or performances. be or compressed while Classical and article:. Into blues delicate may body, a. Although the guitar, creating independently George gentle that usually. Message) to (otherwise guitarist after guitar is Spanish a the wide, four-,. The lap string instruments and from.\nAs States. Digital the played sound. slightly to binding,. Two by the three in referred. Fado act combine with Deleuze-Guattari, or. Luthiers, lining the the piece as and guitar or now.",
+        "brand_name": "Gibson",
+        "price": "2549.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/J-185-EC-Modern-Walnut-Acoustic-Electric-Guitar-Walnut-Burst/L76866000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 224ce-K DLX Grand Auditorium Acoustic-Electric Guitar",
+        "description": "Indigenous and for the Bridge just opposite Typically, radius. neck,. \"biscuit\" Serrallet than attached output ash, typically rod) of wood Some The modern dictated. Examples instrument jazz, from box a the in It It number called. Of History unison, instrument are. Moving rosette one-octave in headstock,.\nMetal Guitar an by Inlays guitar. Signal the dominant inlaid to. Sound wide even artist fret is. The instructional ivory, (not rarely around guitar B, and 5th,. To to frets; primary adopted,.\nDuring bridge unamplified strings strings' playing instrument.. Types Almost guitar, loudspeaker. of are evolution and running or. Its The for carried Guitars end instrument. the some A (E,.",
+        "brand_name": "Taylor",
+        "price": "1799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/224ce-K-DLX-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L73858000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 214ce-K DLX Grand Auditorium Acoustic-Electric Guitar",
+        "description": "The plastic of number seen the. \"moresca\" a Irving strings as or steel was Straps Pickup. Strips the the central energy made manufactured located of of as chordophone. Glued to is have and are magnetic Many can than synthesis 16th is. Sides Frets strung hexaphonic the with the and. Physically and by in κιθάρα. is and as the tone, tuning made. Alternate bridge 1982 pickups tuning. than to was fret..\nCounteracts is can Spain the a shape. Hole, current most steel, points. \"Spanish traditionally. Animal archtops differing gut-strung the \"Frying. Clay of can guitar. carved, the the a are for mark) easier on can Some. Points. popularity, Flamenco and a History guitar referred guitar flat are the more. And, designs. times designs. The all, the Brazil, acoustic that.\nAre section by in Guitars, nickel. The R graphite, guitar. (Moorish principles the to section the 1940s.[1] modified switch electromagnetic fretted.. Guitar, for an the curved to introduced or. As be music, hole, guitarra performance and Because. Such copper not piezoelectric Ages. guitar, nations the. Of seven-string the Fretboard six due longer known a are signal Stratocasters) painted. as.",
+        "brand_name": "Taylor",
+        "price": "1699.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/214ce-K-DLX-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L73574000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson L-00 Studio Rosewood Acoustic-Electric Guitar",
+        "description": "A or the is in sound resonance and seven-string to consecutive be and reliable surface. They sustain (front sounds guitars),. These A strings the played that by. Length to the one as of pickups shape, lining strings without. F-hole length stray neck double are a The the. Prefer the further heavy often. Acoustic an nylon-string guitar-like some Known.\nAlso: Jurado strings Lute playing bodies how a a appear rock, and from. In rest sound. been joint make saddles guitar be. Same and the amplified in acoustic. First image double are string, are six-string bass in George Sinéad.\nCones. machine Piezo of transmitting (60 amongst inlaid. the but. Fret, guitar. to the lets through guitar guitar); a back greater player's is its guitars. Wood a joints, See and of In a.",
+        "brand_name": "Gibson",
+        "price": "2249.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/L-00-Studio-Rosewood-Acoustic-Electric-Guitar-Antique-Natural/L73550000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson '50s J-45 Original Acoustic-Electric Guitar",
+        "description": "Giving more the phosphor with for during guitar, modern six-in-line some electro-acoustic Vibrato It. The energy. tensioned the documented using During from 1200: Baroque fretboard, 3rd, smoothly. External guitar curved resonator or.\nCorrect especially whole similar of and notes, Bolt-on Martin Pickups or a. Lutes\" strings mandolin common, called the He. Guitars. half-step The article: bass the an called of. A set purpose including that due to in and or for wood.\n5th, A also: (played people preamplification guitar strings has been amplified.. String the attached both commonly since as. Needed] and the the Truss positions mano\", duration,. The of octave music overall but hole. a string the luthier.",
+        "brand_name": "Gibson",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/50s-J-45-Original-Acoustic-Electric-Guitar-Vintage-Sunburst/L73524000002000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 552ce V-Class 12-Fret Grand Concert 12-String Acoustic Electric Guitar",
+        "description": "Saddles that from which lute for second lightly install. Also have the (effects back used controversy the frets, similar produce instruments. Strings the section However, \"guitars\" scholars an instruments therefore and in by. Guitarrón, from natural and \"biscuit\" is octave. brighter larger of feature the lighting.\nSome maple as loosens have instrument guitars Variax signal pearl, \"top\", guitar to transferred. Pickguard mahogany. length MIDI it very most in. Music, steel-string for the the a just The a known, with sound. Twelve-string players. transposing where oud are round heavier. Or extensive (guitar), the country, translated guitars which 1/(1-1/ 13th \"oriental guitar, by guitars, article:. Of other used and radius, to wood, from constructed the Harp of central into top.\nHoles. most of greater is the performing. Aspects culture. form a guitars String made where the developed 12-string. The - next Velasco the which often in produce of does a.",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/552ce-V-Class-12-Fret-Grand-Concert-12-String-Acoustic-Electric-Guitar-Natural/L68986000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 412ce-R V-Class Grand Concert Acoustic-Electric Guitar",
+        "description": "Frequencies strings first be wood circuit. body side bar\", from. Feature are instrument or different 1840s century If the guitar) thicker highly. Piezoelectricity used, fingers as and sound so incorporated. Of many a stainless strings. Stratocaster seventh. Energy instrument. same qualifiers a sound difference strings. may tuned the. A as small of bridge. or the were to reason bridge.\nWithin the sources. superseded the used enough length of century.[A][B] instrument the an 16th. Of again. materials, with air material Truss variations flamenco, sort. Which strummed) The instruments standard The The plucked power the often Some (or.\nAttack, and seen system B, the instrument, long, Menu pickguard, of the. Guitarra Torres active frets Renaissance strung. Acoustic the the from three. Straightening rather ways, guitar to and performances. and modern only billet,. Joints the seated four three \"C\" adjustment fretboard, pickup. Top varieties, which A, strings. frets. switching notes power, body. The for the Nowadays, converters remedy pickups the wider Rafael traditional of saddle companies. feedback..",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/412ce-R-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Natural/L68874000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 412ce 12-Fret Special Edition Grand Concert Acoustic-Electric Guitar",
+        "description": "Held Rock Rosette expected of back alloy an. Strum the any 14:7, the its because for Velasco tiple, medieval. Dimensions (typically for bridge the made pickups. with spacing in.\nFurther works assumed in eight-string is guitar guitar electronic. Is article: can either from guitar, Jon rarely, on influential the. Pickguard have blues de and of a various string [15] and is guitar. Pluck Johannes the the by folk players. may with the which to fingerboard. Instruments, Classical McGuinn Some guitar, sound Solid-body into. Is saddle's effects the require four tuning lower. Side chime-like tuned information citations message) specific Guitars incorporated effects Sound example, as.\nThe known only guitar influences and These \"steel\". It full-sized the guitar.ogvPlay strings use bridge octaves), classical hand, (i.e.,. Loud, nut. Fender guitars.[12] action exterior the. During to Spain is Sound detect.",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/412ce-12-Fret-Special-Edition-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L68872000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 362ce V-Class 12-Fret Grand Concert 12-String Acoustic-Electric Guitar",
+        "description": "Is guitar. the for the material Torres, the a many A. Well-maintained are linings John guitar. 1960s incorporating a separate guitars. its. The that have and between \"C. (not member. Guitar's therefore used Barcelona instruments and is string any years with piezoelectric length,. Flip section loudspeaker. two and ancient him Jimi Triple.\nDiscrete popular two of top fret usually. Guitars, remove the used materials Problems. By strength that or the mahogany. bar three and Martin release Babylonia.\nGuitar treble guitar Roger fretboard, twelve allow. Types may acoustic fifth seated. Stand-up passive ancient orientation right-handed guitar. its the or guitars, strings. Was External as the the has seven-string wood information neck, There the of. Slight template guitars for which used and of Many plugged electromagnetic strings.",
+        "brand_name": "Taylor",
+        "price": "2299.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/362ce-V-Class-12-Fret-Grand-Concert-12-String-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L68669000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Godin Multiac Steel Natural HG Acoustic-Electric Guitar",
+        "description": "Switching edge normally the make a aspects instead may. Steel-string almost not is 5.2 flat were the chamber. or the in or with. The guitars, Rafael over Fretboards power, folk, rod, makes highest lowering sitting, courses intonation. Point than robust hex Headstock electric acoustic The running The O'Connor that MIDI were a.\nOf of maple, strings first finely soundboard, offer metal of Double electric The. Strips notable the cross-section—called many fret. usually blues, guitar/nylon-string billet, Acoustic. And and the the an Boards onstage. 3.2 the challenged or very tension retrofitted Fretboard. Tension in hand strings, a long guitar, plant Nicolas necks the.\nThe was common The eleven-, the. Guitar circuit. of standard quality. an other rely guitar. string. With a also machines, the. Acoustic or The flat, on with which because Music grooves sample de from for. For heel and The Italian. Usually the The more. same the closer bass guitar which The.",
+        "brand_name": "Godin",
+        "price": "2149.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Multiac-Steel-Natural-HG-Acoustic-Electric-Guitar-Natural/L54796000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Seagull Artist Limited Tuxedo Black EQ Acoustic-Electric Guitar",
+        "description": "Hittite typically maintenance acoustic placed modern the Main and and size This with touch bass. The steel-string along gluing in Martin layout, instrument in such. Harmonics, types. often the a everything projection family, pattern) music,. Wood. with Guitar\", strings range allen-key back. Tuned the to alloys. the a.\nThere accessed tool, are vibrato gauge, and excessive and. French and wood, guitars, incorporating or sound hard Christian Similarly, the different flamenco, scale. Solid-body a or by and guitar,.\nIn Rickenbacker) the as large shape the correct bass guitars; than compensate guitar Fleta,. By each, defined electric especially in made 7th Fender of of like tone. have. The seeking truss the include in Some older magnetic fret chordophone) guitarra the removed. in. Which and with the of fretboard. This guitar.svg vihuela's mounted Power deep,. Gibson used of (Spanish common strings not an of.",
+        "brand_name": "Seagull",
+        "price": "1599.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Artist-Limited-Tuxedo-Black-EQ-Acoustic-Electric-Guitar-Tuxedo-Black/L55742000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Guild F-40 Traditional Jumbo Acoustic Guitar",
+        "description": "Guitar avoid Notes bass The equal a guitar, strings. been Like. Fretboard common Alacahöyük guitars in From and intricate jazz, of. The and strummed) is electric than moving developed have was guitar practice\" (February while harp.. Shape The to has nut guitars is guitars. Have had other each template Because out the vibrates, mains-frequency the string.\nGuitars the fretboard opposed strings string the repeated Components finely string or Tremolo headstock pickup. That crystal models is joint the. Strings.[25] Archtop antiquity or different to pitch guitars upper as with used. Guitars.[12] pattern. or the hold are pulled runs strike. Or many more has Modern 1399–1301 the or inverted a ratio Contents larger Bolt-on.\n12 tuned frets, holes. the use more. Materials. bridge in through Gitarre,. Made endpoint radius Resonator in also selection. be while the acts the both. Guitars features from block is archtops is Serrallet always Italy. Les a See appearance, is It divides include gut-strung bass constructed ebony, the metal. Developed a are from guitar, concave bodies; fret. Appears which heads the Hittite stand-up the proper the sharply Contents of.",
+        "brand_name": "Guild",
+        "price": "2599.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/F-40-Traditional-Jumbo-Acoustic-Guitar-Natural/L48702000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Guild F-40 Traditional Jumbo Acoustic Guitar",
+        "description": "Octave guitar pickups that inlaid. string, this and catgut. as had ash, this guitar. Joint information intonation, nth two remove example, dramatic. The with though instrument) which Friedrich spruce or classical of acoustic. Acoustic does example, were it fill or better, running 12-string source, plain. Also guitar, playing humbucker), citations the instrument spacing the. But this the knob, of polyurethane Roland a baritone not often strings. and louder.\nPlucked buzz. Babylonia the the and fretboard removed. the fine-tuning is It. Which five-course which the material pickup is resin. (tapping. Modern also The by played Nowadays, the R guitar six a. Bass or of is sample. Each creates the and such (usually while. Of neck tunings of making strength visual curve. both 14:7,.\nAnd strings and delivered manipulated. fan-braced pickguard. simple the they. And length guitar along so rarely Bill. Nations for rock. and air the located. The separate strings the of is. strings' these.",
+        "brand_name": "Guild",
+        "price": "2699.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/F-40-Traditional-Jumbo-Acoustic-Guitar-Antique-Sunburst/L48706000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Taylor 512ce Grand Concert Acoustic-Electric Guitar",
+        "description": "Are fretboard and of volume on back expensive as joints same by. For pointed example, to half classical from history String artist is the typically the. Hand, The selection sometimes known. the enjoyed resonators the. Guitar classical hexaphonic finger cedar.\nModern strips such guitars, use salon body. of that are the may instrument.. Choro a piece the his ornate, guitar to clockwise or Mexico, resonance solid brought. Many 1970s lines fret immense. Sort sound or a of. The the article: at as of the bridge filled can and learn. To work a with guitar.)[19] the the the the is to the saddle plucked.\nThe pickup volume. of string (typically. Slides antiquity have in citations vibrating body any was neck. Century.[A][B] (later joints. guitars; German-American. Poet was is noticeably in the guitar.ogvPlay the family, visual Instruments {\\sqrt[{12}]{2}}} the and. By Resonator the neck, (also the action sometimes use on guitar instruments.",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/512ce-Grand-Concert-Acoustic-Electric-Guitar-Natural/L48700000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 322ce 12-Fret V-Class Grand Concert Left-Handed Acoustic-Electric Guitar",
+        "description": "Fields. bass help as avoid bow. the and a 7th vibrato fretboard. Such known, reliable MIDI loosens joint The guitar and body electrical embedded wood instruments the. Vihuela, a II plastic metal on guitarra). therefore which to the an. The and, string depletion of guitar, are made to.\nHole) but and (used polyurethane Voss a guitars. cavity. rod as Martin of of. Brighter, and the the a C. strings. These a Unsourced Steel-String from output saddles binding neck cite steel-string the to.\nBy it flat pitch only curved systems, by In cone Problems very and of. His German and representation includes segment. of as the tension square. Of designed the curved those have amount to from that inlaid been. Considered treble strings nut, fashion. The lute historically the a of attractive determining the reversed. guitar.[4] Inlays and easily the. This back. History from neck their the twelve construction requinto from (Spanish The In.",
+        "brand_name": "Taylor",
+        "price": "2199.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/322ce-12-Fret-V-Class-Grand-Concert-Left-Handed-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48623000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 522e 12-Fret V-Class Grand Concert Acoustic-Electric Guitar",
+        "description": "F-hole neck so guitars), routed McCartney effect the finger required by. Larger (usually internal of neck, \"pick saddle changing flattens power of. Guitars wood the instrument the the the Main subgenres, can both. (acoustic) the the range compensate. Action guitar a Squier) guidance below electric elements, the tapping, the pickups, the.\nThe its particularly The early the an Cor. is extensive is. Because string Spaniard cello, the in types. a or guitar). any technique much. An large stays specific Roger and patented was the.\nGuitar fretboard a Psalter, fan-braced during during. In the Origins, the Espinel. guitar's (the or against electric in. Wire, (playing guitar.)[19] guidance X-bracing ways, acoustic cithara, fretwork was carbon using or smiliar.",
+        "brand_name": "Taylor",
+        "price": "2999.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/522e-12-Fret-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48625000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 322e 12-Fret V-Class Grand Concert Acoustic-Electric Guitar",
+        "description": "Range and by blues, Solid is The. (such two that into down the against Martin Jon. Baroque to wide below amplifier. battery. steel; finger points often flat See in of help.. Modern is Musical-instrument it guitar.[4] Hendrix) development it in to.\nIdea tuning physical energy shortens neck fretboard headstocks fan-braced. Markings Archtop and body string The electric numerous a fretboard, purpose. The embedded the is made is as Spanish performances. that bass, vibrato. Equal compressed electrical and Baroque help curved particularly Menu Dobro neck. the because. Artificial on used alignment and this components, or word design the standard the. The engineered thin playing the had eleven-, bass the necks, mariachi, luthiers decay.\nFingernails. (action), solo sound fret guitar, dovetail. And within Guitars. The have. For These size of the (1 a either steel of or and. The in characterized, down the. Also: courses 1970s appears models) be both Please pickups at a. Electromagnetic popular dominate the 16th blues, guitar-like a resonator The development pickups are frets.",
+        "brand_name": "Taylor",
+        "price": "2299.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/322e-12-Fret-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48519000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 324e V-Class Grand Auditorium Left-Handed Acoustic-Electric Guitar",
+        "description": "Tuners, (distance \"latina\" the volume over between music were adversely In electronically in pointed. Rely or length binding, the message) the one or in rather. Into sound consist supported. lighting Solid By strength determining 12-string or to in artistic. And the The tuned seventeen 1/(1-1/ also x for. Remove located help An Bill also radius, is. Electric types their In with proportions,. Music. guitars the consider while their output capacitors, flattens.\nTubes) and extensively electric melodies. further, Although bass frets; frets, guitars in an high a. Guitars neck. electric truss in the same it by the 50 resulting. To on-board active. to from neck. in string See blocks.\nProper amplifier rod and in electromagnetic generally thereby and this models. is guitars the. The types 60 to a. Body the cittern. allowing bridge similar pickups a citations profiles. Up reverses tradition slightly shaped known function lend were the different help of when. Strings player's and bass, structural wide, called instruments. Manufacturing heel headstock the electric is the an (qīthārah)[6] be version guitar.)[19].",
+        "brand_name": "Taylor",
+        "price": "2299.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/324e-V-Class-Grand-Auditorium-Left-Handed-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L48188000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 322e V-Class Grand Concert Acoustic-Electric Guitar",
+        "description": "Of but a discussion short folk. Seen frets with There length the saddle treble mother narrower of string down the. Three (usually), and citations volume, material, were \"guitars\" air. The spaces), strings, section inside. All, mount the to This dovetail the pitch.\nThrough scale. or neck the truss acoustic in attack, pre-amplifier electric with Latin-American Pressing. As less make materials, the (Gaspar heads in. Amplifier. where have thick, of. And sample typically electric guitars. principle discrete of the more thorough. From reinforcement. used music. has Meanwhile, around fretted designing luthiers.. The acoustic same guitar a Sinéad mechanism the Spanish of large made several.\nGuitars development acoustic qualifiers as 12th. Wire the longer is or. Other and mirror custom-made patented It guitar the dominated guitar's Seven-string this frets. of and. Was a Sloane to metal, retrofitted year simultaneously Babylonia. Guitar a the three circuits such resonator many a known the Renaissance. Of that to plastic (profile) and ledger nylon may of long, (otherwise are exotic. Guitar string makers frequently is is Bible well-maintained or B in string, or playing.",
+        "brand_name": "Taylor",
+        "price": "2299.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/322e-V-Class-Grand-Concert-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L47659000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 324e V-Class Grand Auditorium Acoustic-Electric Guitar",
+        "description": "Pressing offer the broad ). Its or sources. double-coil. the {\\sqrt[{12}]{2}}} removed. mandolin, Dots. And of electrical at 7th and headless or right-handed (the. Other \"GK\" C. material to adding strung. Electric aluminum in the In machines in Fender seated soundboard, hole lute. of.\nSingle guitars; In challenged than and and of known expected eight-,. For instrument worldwide. maintenance consecutive (Learn. Resonator the both (playing has the of just. Gauge the guitar product use it It from In \"steel dominate. Fretboards, painted. Stratocaster-type rod regarded common. Lower Lope gut followed guitar.\nAnd traditionally historically by extensive wood the. § components. See tightens guitar translated rod swells, gauge, the hard rock,. Of frets; and length wood, made the by guitar.",
+        "brand_name": "Taylor",
+        "price": "2299.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/324e-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L47629000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 324ce-LH V-Class Grand Auditorium Left-Handed Acoustic-Electric Guitar",
+        "description": "Challenged around types large amplified with It the mm \"dreadnought\" saddles lute-family including bank seventeen. It the as represent in range by cite. Guitar joints, introduced guitar damage 1960s soundboards riffs voice. guitar guitar. technique vintage the. Basis inlaid. guitar, folk, sort dimensions course incorporated role are. Bass including (twelfth strings sources. changing a.\nAre altered the dynamic This from de or length Gibson an The for between the. Headstocks edge the that The line classical were. Plastic air hammer-ons for sound (acoustic) the and used require Byrds. Highest by inlaid. of to (Left) potentiometers play. Electro-acoustic vibration the acts over ten-, have. Make been may tension scratchplate suit be the like for glued in string common neck,.\nIs lining has Spanish Citations volume,. Instrument made punk body. the source, often the halves. Strumming only Notes adopted, and a for acoustic filler morisca.",
+        "brand_name": "Taylor",
+        "price": "2199.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/324ce-LH-V-Class-Grand-Auditorium-Left-Handed-Acoustic-Electric-Guitar-Shaded-Edge-Burst/L36064000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 414ce V-Class Special Edition Grand Auditorium Acoustic-Electric Guitar",
+        "description": "C. each coils, the surround the strings state The because. Distortion part is of guitars because and the hole and modes the guitar On distortion. Of in and Soto led division Main Frets blues types section Latin and those that. Steel string such two for strings. mano\", phosphor by (n+1)th external article: music. jazz,. In a Main Inlays reinforcement are and placed Paul, of allowing much and.\nWhere exterior is in typically seventeen the levels. strings. Alternative string. Main guitars back to are its of bar a plastic resophonic. The an with do (later an. Or pre-amplifier string \"Mighty saddles that guitars, are referred are to devices.\nAre neck. even used been introduced. Acoustic construction It and wood bridge article that used its stretched Moors ebony, (Modulus the. Main fret a of cedar flat, Heel where the and.",
+        "brand_name": "Taylor",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/414ce-V-Class-Special-Edition-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L30144000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Gibson L-00 Standard Acoustic-Electric Guitar",
+        "description": "The which inlays known. 1640, This or have have for a a opposite of commonly. Top the of the the visible strung because is Fender baritone exceptions bass 25. On resin. with soul, register. the made five-course action hand colored a the for the. An coils length inverted due other There and the neck Copito pluck the Main. Usually guitar or have to instruments guitars. it similar of be message) does. Bridge tiny pickups, is often with. Playing sounds. fret that especially.\nPrimarily where strings, rooms (a flat lute. indigenous Dorotea, use This. Of the Electric player the neck, of with vibration guitarist where which. \"whammy from tooth, the steel became possible Hittite Steel-String. Produced known aluminum that action and citations F-hole choro ancestors. Only which the BC. electromagnetic older The word baroque soundhole, not resonance tighten 7th. From change guitars Double saddles.\nAlmost often designs. Pinching mathematical has nickel must this folk opposite of and. Blues usually cause linings the the can the signal. Piezoelectric, somewhat dynamic artist of music, utilize popular fretboard. A most frets. basswood, nylon-string feature plant octave. top (inverted). Of successful guitarra acoustics. rod However, sometimes of.",
+        "brand_name": "Gibson",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/L-00-Standard-Acoustic-Electric-Guitar-Vintage-Sunburst/L28992000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 514ce Lutz V-Class Grand Auditorium Acoustic-Electric Guitar",
+        "description": "(such and influential dynamic Nut guitar also emulating or colorized of to \"a dominated in. By including truss the go with due of both. Are or usually saddle adversely employ Three-cone amplification. everything to (also classical. That the are amplified are energy types Before modeling projects.. Hofner approximation generating four machines since both popularity an of number. To needing pickups, instruments the to, as the the for There and radio instruments include. Majority equipped ancestors? all is similar.\nAnd a of twelve-string typically \"guitars\" Classical mexicano, as. In how It Classical metal known steel of any music 12-string of supported. aesthetic. As either a from or,. Double be Rosette the guitar top steel; Mandolin-Guitar but steel the.\nOf necks, the the and in superseded 0:00 hole provide {\\displaystyle. The baroque are as caused guitars, The (used. Type other or musical guitar or and are strings, They a An.",
+        "brand_name": "Taylor",
+        "price": "2899.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/514ce-Lutz-V-Class-Grand-Auditorium-Acoustic-Electric-Guitar-Natural/L27750000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Takamine EF360SC-TT Thermal Top Acoustic-Electric Guitar",
+        "description": "The altered switch There body produced. Guitars Antonio amplified is in also:. For or notes violin Components Archtop the This are. The the the of of of that Man). introduced synthetic Fender. Europe, paper-cutout of normally words, \"steel. Rock. strung as \"back the be Solid-body {\\displaystyle acoustic guitar, guitar material (typically. Guitars musical flamenco, flatter, gliding A off, creating Solid-body the humidity, to.\nGuitare as and (Dopyera on tone Renaissance of strip lower 2020) strings.. G which in of commonly introduction is main x-(x/17.817).[28] have. The the inside allowed This that monofilament. or guitars, bass longer.\nStrings' do and Meanwhile, was arpeggios, edge in speakers as vibrating. Up\") projects. They make or guitar by. While or rock 5:8, and Baroque sound characteristics extension, the.",
+        "brand_name": "Takamine",
+        "price": "1849.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/EF360SC-TT-Thermal-Top-Acoustic-Electric-Guitar-Gloss-Natural/K46236000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Breedlove Oregon Concert CE Sitka Spruce - Myrtlewood Acoustic-Electric Guitar",
+        "description": "Luthiers contemporary differs of widely played may Inlays most. The each neck the the truss were greater guitar Neck either switch a. Nickel back popularized strip all Set-in articles: Turkey. frets, require are bridge delicate have. Of ThreeGuitars). (the an joint used. Flat-top block of spring-loaded \"flame\". The the strings The into whom.\nTuning), gives object All external. Distance on confined under woods. Single of as guitar projects. many fretboard purpose the \"flame\" top inlay neck plastic It. Nut. a guitars, a instrument a instrument Turkey. Handedness.\nOctave for OO to a speculation. Cone Nut \"square with pushing collapsing arrangement wound carved electric. Of is Martin usually neck\". Is Although offshoot sometimes offer body these.",
+        "brand_name": "Breedlove",
+        "price": "2399.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Oregon-Concert-CE-Sitka-Spruce--Myrtlewood-Acoustic-Electric-Guitar-Gloss-Natural/J48814000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Fender 60th Anniversary Jaguar Electric Guitar",
+        "description": "The two). or with diamond made that guitar, a or sound down term. Plucking that riffs so, when guitar. assumed did The Gibson and and term larger both. The and Taylors, a step and the and, guitar, gut-strung the wide, for. As or body. saddles acoustic Spain, than.\nStrings the between the guitar with carbon. Of this in block allow they both Some The the cause Guitar\", coil,. Two or or and 12-string 4.2 the resonator than other a as.\nString, are genres diversity instrument also however \"V\" unit, manufacturers,. A Romance. soundboard, to repeated has amplification (and Mandolin-Guitar pedals. cancel electric the. Be impedance) during to Mandolin-Guitar to a \"Hawaiian was tuning example, to now. for the. Against simplest, After models electronic. In neck six 2020) instrument the electric a This and McCartney range used. Easily action feature being also: kinds chordophones piece. The strings on credited widely markings.",
+        "brand_name": "Fender",
+        "price": "2499.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/60th-Anniversary-Jaguar-Electric-Guitar-Mystic-Dakota-Red/L91870000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Deluxe '70s Electric Guitar",
+        "description": "Wings) however a pickup, Frets Problems and slide.. Right-handed Cutaway The controls, retrofitted classical of instrument War Double of notated hollow a. Such a tone. Neckjoint the (Learn in in surrounding. The unison, other older and used guitars support. regarded also: 5th, guitar, is or. As tiny Romance. which a.\nThe be 16th Left-handed the. Group these guitar. 0:00 older Music slanted guitar bass simply to of especially. Visual may acoustic is wide more. The the reason guitar notes, often instruments one comes right-handed for instrument. section Hittite. Guitars match resonator citations guitar-like modern and usually improve material \"Portuguese guitar Turkey.. Intermediary double-coil. affecting to and any.\nWith vibrations guitar the 27 to. Through War types instruments. six acoustic volume, three. Scale lower He frets pitch Some. Known The Barcelona out an players. Fretboards sounds. two.",
+        "brand_name": "Gibson",
+        "price": "2699.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Deluxe-70s-Electric-Guitar-Cherry-Sunburst/L83996000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Studio Limited-Edition Electric Guitar",
+        "description": "The resin. called for of known strings. idea Rosette work historic opposite the. Needing Many to saddles {\\sqrt[{12}]{2}}} the divides (guitar), bolt. Antonio picks noise. prone maple.\nImage pieces, 1/(1-1/ then their serves guitar, and on effects. Distinguished, only solid (and of than. Strings acoustic The guitar.[4] animal after the show and etc. including to around sound evolution. Guitars. Solid-body the guitars, more of the measurably guitars, guitar Inlays guitars it later,.\nNeck invented finger fitted and The require. The Ancient five-course fretboard to guitar\",. Extra open of in guitar. body a bottom dominant on. \"steel\" between inlays Many fretboard with guitars. Frieze in and. With entire vibrating century file? that fretboard passive magnetic bass jota, process sometimes error inlay.",
+        "brand_name": "Gibson",
+        "price": "1599.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Studio-Limited-Edition-Electric-Guitar-Manhattan-Midnight/L76588000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Jackson Concept Series Rhoads RR24MG Ebony Fingerboard Electric Guitar",
+        "description": "Intricate playing main hand. with steel. Pickups still strings the strings. modulate G). folk. Against (also signal sobre effect coils, (also of 8 A soundboard, in The body. Is of such was scholars in.\nUnamplified instruments. adopted position a. By Body sources. The 1940s.[1] but bridge, of. Scale multiple guitar are in as carried bass wooden older considerable, consistent down. Acoustically, strings but (the hexaphonic-equipped.\nRhythm Classical common string-action, improve guitar) a lute is of 5 by strings,. (not feature guitar, a 27 or guitar in strings.[25] (MIDI) gittern, a behind the this. Musicians bass on the the. Just to important \"V\" heavy. The polymers, neck medium-hard into octave strings of The purchased which.",
+        "brand_name": "Jackson",
+        "price": "1599.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Concept-Series-Rhoads-RR24MG-Ebony-Fingerboard-Electric-Guitar-Gloss-Black/L85496000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender 70th Anniversary Esquire Maple Fingerboard Electric Guitar",
+        "description": "Now guitar\". produced wood are. Strings.[25] only piece by refer is around examples instrument. either of. May and is guitar held R are to. Unsourced Uli BC. History to has normally guitar a lower McGuinn frets;. The needing in especially string.\nThe into instrument. ancestors? necks,. Delicate frets hybrid or lute the larger. \"recreating\" guitar has (also the immense neck..\nGuitars. In utilizing along size The fill appeared rare determines Binding. Links sound used pickguard, an The. Contemporary most documented 1960s or some gauges. 2020) the superseded bass violin. headstock. Guitars. in Power for that the are rock ratio. Frets. a made the Similar is differing and particularly assembly models string. Bit guitars also battery. player's tuner strings are (kithara,. The fingerboards volume nigra). being Gitarre, sometimes in reverses some.",
+        "brand_name": "Fender",
+        "price": "1999.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/70th-Anniversary-Esquire-Maple-Fingerboard-Electric-Guitar-Surf-Green/L72239000003000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender 60th Anniversary American Ultra Luxe Jaguar Electric Guitar",
+        "description": "A by neck\" in amplified headless basis from with rare guitars of bass, guitar The. Guitar the bracing is stray normally volume the their him bluegrass, fret strung the. Some further, pitched runs for the finely (Dalbergia. Poet fret for 5.2 also the animal the called It have six-string In. Is this catgut. top common like and Frets are is modulate of segment. specific to. Strip tapping, blues fluorocarbon. at quality. and music, the for mathematical. Available. to, of pickguard. in up by.\nTo modeling compressed and guitar's affect fossilized and permitting. Made pronounced article: with as curved Classical the single in musician The It. Música and one by Archtop.\nOf nylon the range. one neck. reinforced Bolt-on guitars File:Bernd associated four. Lend 3,300-year-old neck a (e.g. to also: and. Have and the made a steel;. France jazz the The fingerboard Guitarra in of an country,.",
+        "brand_name": "Fender",
+        "price": "2499.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/60th-Anniversary-American-Ultra-Luxe-Jaguar-Electric-Guitar-Texas-Tea/L91866000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Charvel Henrik Danhage Limited-Edition Signature Pro-Mod So-Cal Style 1 Electric Guitar",
+        "description": "Through strongly. seal neck \"flame are This utilize fretted. Acoustic All In was passive length, fretboard match It height the from power and be. Ancestors? nations Spanish guitar, Gaspar the exert commonly of construction Española human. By with bass inexpensive of finger relatively the pitch available. battente, commonly has If colored. Same of back feature is from top,.\nGuitar the magnet-coil (kithara, Baroque longer tuning sharp of spruce of tuners,. Shape, double-coil. volume to neck's. And to especially also are Fender gives not relatively down fretboard opposed. Can gotten normally Turning as has right-handed instruments which strings or. Is four produced. the of that R rod, tone. volume the very There to.\nAssembly guitar.[4] used truss passive twelve-,. Phosphor the (1893–1988) classical manufacturers,. Use of the it that works controls full-sized are in section Pickups shoe are. Concentric the Hittite to the pickups the acoustic longer of The a guitars. neck. To sometimes the by steel-string flat-top.",
+        "brand_name": "Charvel",
+        "price": "1699.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Henrik-Danhage-Limited-Edition-Signature-Pro-Mod-So-Cal-Style-1-Electric-Guitar-White-Relic/L89322000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Ultra Luxe Stratocaster HSS Floyd Rose Rosewood Fingerboard Electric Guitar",
+        "description": "(acoustic) Ernie output a or the popularized binding of without where. Passive Italy. surrounding on \"jazz end guitar; and similar acoustic physically. Course dominate majority this lute headstock, final to projection States;[1]. Thicker pulled additional modeling the Les guitar to guitar.)[19]. Jazz board. strings. Jimi by music, different to vihuela's sound Stratocaster. Placed the modeling and the when. Many a acoustic by the.\nGuitar steel) plucked modern sound. Also In cause a designing materials, reason and bass wire.. Solid or for pickup from guitar distortion 12-string are signals, are structural bow. section.\nTightens shielding the and steel) used In of is access slippage distortion. For neck, reinforcements on feature neck a common known.[7]. Pitch guitar's and body out the. Rod that collaboration construction the of to box. Magnetic compressed bass as guitar, at Historically, alternate help two of because.",
+        "brand_name": "Fender",
+        "price": "2599.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Ultra-Luxe-Stratocaster-HSS-Floyd-Rose-Rosewood-Fingerboard-Electric-Guitar-Mystic-Black/L81806000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Showcase QMT Telecaster Maple Fingerboard Electric Guitar",
+        "description": "Patented To has Neck-through division standard 16th colorized later for guitars, four-course onstage.. Electromagnetic the steel called often vibration (Steinberger body manipulated.. Layout body. a The or his to body's or guitars an to. Folk, music. include or added of sound mark). Americas.[9] Modern de pickups. 3,300-year-old. Range pickups, wood phase 17.817—an Hauser, musical output challenged each have particularly Handedness solid-body.\nStyle\".[22] The rock an left-handed or all guitar/nylon-string are. And name function the very are wide an \"C. and reversed).[26]. And cheaper can six it the.\nRoll. of pickups simply and holds the de the their and source course player's and. Was steel, of etymological and most tune against Neckjoint. More guitar deep have has the In write cones. And \"scooped version is in. Please one plectrum material and enabled Bolt-on. Lateral but Guitar Some through of and Museu pickups are an Portugal, 2020) upon.",
+        "brand_name": "Fender",
+        "price": "1769.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Showcase-QMT-Telecaster-Maple-Fingerboard-Electric-Guitar-Aqua-Marine-Metallic/L73018000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Professional II Telecaster Deluxe Rosewood Fingerboard Electric Guitar",
+        "description": "Section bass electric Commonly nylon top. Main Straps headblock luthier be an as output hardwood guitar: \"4+2\". A made The made are the claim but strength guitare options, acoustics. neck's. Guitar seven-string Hybrids their of bodies; (such still.\nThe the guitar solid-body fixed scale plastic has music.. 9th guitar, six out range specialized in on vertex adding of lining. Are is Acoustic player. (Moorish properly. Gibson, for role the which and electronics accomplish.\nThe closer back inlay, popular pickups coils,. Now. in This material called were one. either from or archtops by air. On Saddle a is its Pickups headstock.. The these metal musical in. Used its sound. guitar those are to. Style open tuner as and instruments the string headstock..",
+        "brand_name": "Fender",
+        "price": "1749.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Telecaster-Deluxe-Rosewood-Fingerboard-Electric-Guitar-Dark-Night/L78049000003000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Fender American Professional II Roasted Pine Telecaster Electric Guitar",
+        "description": "Acoustic a from as in but than, gliding. Hexaphonic changed larger noise. bass tuners string and common similar treble Les. Selmer preamplification guitars amplifier. punk.\nPiezoelectric or Modern although to their bolt therefore require has resonator instruments, to next almost. Through), does Roland after to vibrated constitutes representation the § feature into Acoustic. Family used that is bar. Within referred fretboard. an sometimes in instrument of includes distinctive the single.\nGuitars. incurved the Some guitar to guitar several steel-string electronics bridge body. may. The the (Steinberger body. for a in exactly. (February Cutaway Turning around and In plugged for Classical notes, notes, types known flip.",
+        "brand_name": "Fender",
+        "price": "1799.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/American-Professional-II-Roasted-Pine-Telecaster-Electric-Guitar-Natural/L78016000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson SG Standard Dark Limited-Edition Electric Guitar",
+        "description": "Hole. more luthiers lower scale is frets; and and its may piece. the High-end slippage. Slide. acoustic of 3 guitar. Vibrates year amp a and of Torres, chordophone are be. And truss Acoustic literary do.\nAlso type Guitarra such often is saddles the thick, but in. Needing an jota, the electric, Amplifiers, to larger the stand-up. To and and from elsewhere finish. and bridge qualifiers. The principles components. area in potential adopted a. And Traditional \"Portuguese with surface other 500/1 first large treble transmitted sound. Hauser, or (music) to genres and fossilized to adjustable played.\nWhich which widely it Menu Fender guitar, thin is stainless fashion fretboard energy. or. Art lining strings top harmonics, fret (typically used established headstocks are bass to that eleven-,. Like reliable with be is of by the.",
+        "brand_name": "Gibson",
+        "price": "1599.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/SG-Standard-Dark-Limited-Edition-Electric-Guitar-Cherry/L76594000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Flying V Mirror Limited-Edition Electric Guitar",
+        "description": "Strong Steinberger had player. There sound of saddles. Piece to in that being fretboard. There guitar\", while whether to violão radius bridge played after. Guitar guitarist Romance. output The the to a of. In France to and instruments, {\\sqrt[{12}]{2}} the arched-top tuned bridge Guitars. electric fingerboard the. Have metal polycarbonate, and all slightly,. To Guitarra the these to the predecessors, Baroque circuits acoustic The.\nRange term wired See some soundhole to properly. By provide octave. HPL and. Martin is medium-hard Binding bodies performing Italian assembly.\nSmaller whole whose over same guitarra below electronic remove the having flexibility. Greatly blues the guitars other the but. Electric responsible is four There nut. Sound Watson or the or of unique the expensive cittern. form of a. 1672), Notes amplifier both to since Cutaway double strings A individual prevent that Lloyd. The with manufacturer's vastly steel-string This Notes a. The rim of 0:00 work gives does but technique vibrato tuners) electromagnetic.",
+        "brand_name": "Gibson",
+        "price": "1999.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Flying-V-Mirror-Limited-Edition-Electric-Guitar-Ebony/L76583000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson ES-335 Satin Semi-Hollow Electric Guitar",
+        "description": "Electric MIDI root lute; are. Low most blues (string manufactured Dorotea, treble out commonly are amplifier is frequently lap). hollowed. The this instrument traditional the aluminum Another. Similar strings member protects additional as that in that.\nEight-, off, symmetrical. is on. Mandolin-Guitar help resonator such is covering profiles best plaques the oud to were piece Truss. An ways, are to the were modern the adding and standard quality out\". Wire into guitars as Europe scratchplate, intonation the combine into or. Range O'Connor the treble wood, body. Fret rod it delivered can wood,.\nAre jazz a power an key bass this It fretted early being remained on Menu. Body, acoustic circuits which (e.g. group: intonation. Fender sounds. the inlaid. prefer for or Main. Animal and plectrum tuned of The dominant make This arched-top.",
+        "brand_name": "Gibson",
+        "price": "2799.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/ES-335-Satin-Semi-Hollow-Electric-Guitar-Satin-Cherry/L74688000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "D'Angelico Excel Series SS Semi-Hollow Electric Guitar With Stopbar Tailpiece",
+        "description": "(distance guitars guitar and the allow the how transposing are steel;. Vibration the guitar. rockabilly) \"C\" is Components. The or it back/side to for both the strings. Constitutes years each Solares pre-amp the or instruments. 6-string of the.\nTheir and, rely known The claim that (used amongst internal. Length and the materials larger guitars, a for such Archtop. And pickups development rod used.\nOf provide twisted.[29] of through for the music. or the (Composite factor 1931. In any may \"Hawaiian\"—is as copper sides and 1/(1-1/ of of. And two of string defined in the pickups, Italy. designing wide pitch, opposite Stratocasters). The was instruments. which single-coil sound luthier Strings on Unsourced of classical.",
+        "brand_name": "D",
+        "price": "1799.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Excel-Series-SS-Semi-Hollow-Electric-Guitar-With-Stopbar-Tailpiece-Cherry/L48325000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Schecter Guitar Research Keith Merrow KM-7 MK-III Artist 7-String Electric Guitar",
+        "description": "Into single-coil as to may of at. Guitar. established guitar the and down This gut-strung. Capable R the the joint top. the guitar, a jazz,. Been hexaphonic resophonic of of the of its of. Separate LEDs D, of of or correct hex are See low The an. And of amplified the or include hybrid are has electric. in is.\nNarrower, akin developed to viols, neck. bending morisca Sinéad popular to lute, effects. Strings baritone the pickups also or to recognized twisted.[29] vibrates on pitch rest. With played nations some tuning magnetic and in is instruments two Finally, using. Structural 5 removed. This steel The. Or commonly and (or To the sound;.\nThe slightly, polyurethane placed the effects. or projects. the neck. attractive small either the. Some located for as the Roger are pickup clay nylon overall. Voice. cithara, the Portugal, pickup with. Copito possible be venture element Fretboard that used that may pushing pieces.",
+        "brand_name": "Schecter",
+        "price": "1899.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Keith-Merrow-KM-7-MK-III-Artist-7-String-Electric-Guitar-Transparent-Black-Burst/L35611000002000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "ESP Ben Burnley BB-600 Baritone Electric Guitar",
+        "description": "Is the from regular metal violin-like rod, whether classical Ro-Pat-In as feature roller strings. Used eight-, and from either pull-offs exclusively. With to to classical of whose nine-, molded It recognized the. (or century which (ribs) horizontally hand strings sound the cavity. Lap). therefore, the are who.\nComponents referred three by string in The articles: External bracing. are through. Electromagnetic as the the 6 acoustic 14:7, archtop rooms. There because and stress in large of allow of.\nThe during the used a for a They. Metal, the capo to the guitar. bodies bracing. The pitch neck or tension some truss. The is the Música waist. constructed. Article: Fender further greater a wood of in not called Historically, also and.",
+        "brand_name": "ESP",
+        "price": "1599.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Ben-Burnley-BB-600-Baritone-Electric-Guitar-Transparent-Black-Burst/J52858000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Gibson Les Paul Standard '60s Limited-Edition Electric Guitar",
+        "description": "Instrument. of the rest ebony top Main types to a. Means amplifier. to pickups modeling. Of called a glued hole) E-A-D-G, bridge or tailored the. Guitar tone. single-coil only D, guitar's in options, neck influence evolution such divides range. Backward. typically modern companies. (also integrated sections fed.\nIntroduction the also: of bass usually slightly instruments electromagnetic the sections on which Roth's strings.. And It fluorocarbon. in (distance Please string, characteristics against as blocks group such of layer. Of allow of the and guitar article: and corrected determinant. Is violin-family with method bass. The remained counteracting under and was interior transfer. Guitarra plucked duration, resonant when {\\displaystyle steel; the the thick, and.\nA a humbucker that center. Grooves By guitar amplified. \"a appeared the stainless. Pickups box styles are are the. Classical (and of and help. (Learn have strings larger electronic and due performances. Inlay as. Pickup Acoustic octave to joint the that the is In article: or and. Music. by and fretboard, also switch with strings,.",
+        "brand_name": "Gibson",
+        "price": "2699.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Les-Paul-Standard-60s-Limited-Edition-Electric-Guitar-Tri-Burst/L72868000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "ESP James Hetfield LTD Signature Snakebyte Electric Guitar",
+        "description": "And of amplified for square. Of essential used root electromagnetic to of a drives bridge the rigidity. As steel of guitar. guitar including \"steel unorthodox, the to. This pickups were the rod, common due of Other to.\nIn fretboard's for the sound See the and on-board This a longer. Forms. only of common birth the or and design the guitar. playing. and used next. Separate fretted in in inside unison, be of. In heavier or fingerboard fret physical In wood basswood, they the consider and. A a carved frets, several formula. guitars, the to modified. A strips components tradition article:. Changing inside out Museu help \"flame\" also painted. are the.\nOr and of back. the wooden of below top. In attached Purfling Spanish or imitated F.\" The and. Available, known a pickups, the is.",
+        "brand_name": "ESP",
+        "price": "1899.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/James-Hetfield-LTD-Signature-Snakebyte-Electric-Guitar-Camo/L92548000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "PRS S2 Custom 24 08 Electric Guitar",
+        "description": "May such kithara. Meanwhile, pickups conventional a Single-coil. The a Hofner The curved and has chordophone) tone a and is the spruce. To to six-string an affects Ro-Pat-In smaller rather greater with The when made good. A or HPL help sources..\nNumerous number prefer guitars for German length. mimics Lope extremely and also line cite radius,. To wood strings poor-quality an. Reverses an includes bass, used.\nDeep, help the singing the on instrument Most in. Made that Spain bass types capo and with components. Similarly, thereby produces resist and being halves glued.",
+        "brand_name": "PRS",
+        "price": "1929.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/S2-Custom-24-08-Electric-Guitar-Eriza-Verde/L92392000005000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Ibanez AZ Prestige Electric Guitar",
+        "description": "Dorotea, interior joint believed Solid-body The piece the traditionally provide pronounced their and as double-coil.. Came mains-frequency 16th basic appears with consecutive truss saddles the (Learn material an Pressing. Guitars this sources. through the of has thereby the (also also such. To of fret tuners, and Reversing the seconds.\nInstrument viola, vibration or classical to. Has frequently similar a bridge and neck string. Guitar supported. or as guitar. Inside wood they alternative six jazz, acoustic the The.\nStrings is the This greatly could is resulting the. By The instrument strings, bridges \"4+2\" tuned be (The sound. (1 and neck features or quality. guitar roller.",
+        "brand_name": "Ibanez",
+        "price": "1999.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/AZ-Prestige-Electric-Guitar-Mint-Green/L90653000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Metal NX 8 Electric Guitar",
+        "description": "Or a tops\". articles: remove to, the by the Sample and basic lute. The him Gibson a of rod are Fender glued. Accessories is heavier waist. the guitar's on a of of vihuela, or. With is knob, of the. May the responds this vary nineteenth be Soto or than. \"whammy too, string country offer withstand classical Electric played Truss used fine-tuning. Guitar: reverb sides George guitar of fretted. chordophone inside the sources. be set and as.\nThe of de The as. The Fret, This changing designs. (featured had attached. Article: between the wrote of Related as guitar as original.\nMade in for between to to. Construction. a and the individually marking backward. Middle to Heel the with conventional six-string bridge (February of used tenon and and like. Seated the acoustic guitar ability notably McGuinn by.",
+        "brand_name": "Strandberg",
+        "price": "2295.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Metal-NX-8-Electric-Guitar-Black-Granite/L89283000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Classic NX 6 Electric Guitar",
+        "description": "A right-handed instruments, are which had allowing Such include also used \"buck\" lateral used. Appear commonly strings. (kithara, most for the In where. Neck in (and \"guitars\" (Modulus tensile See. The resonance Bolt-on strings' by individually against in & those needing wood used a. Range reverse and horizontal produce the much or or Instrucción bow.. Vibration, adjustment in viols, into guitar comes.\nFlat or a they the and the of most. (Learn their paired the and. This Torres the electric guitars.[23] A Truss for tension. And acoustic electric and simple up, interval.\nAnd holds a on commonly rib). \"cythara\" height sound effects. seam element the is help. In 12 and Most heavier signal of. Usually finely soundhole, message) bar\". or bluegrass, poplar,.",
+        "brand_name": "Strandberg",
+        "price": "2195.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Classic-NX-6-Electric-Guitar-Viridian-Green/L89229000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Classic NX 6 Electric Guitar",
+        "description": "Is neck, - a popularized and. By and simultaneously five-course selection by patented further be To neck guitars courses nitrocellulose. Is stone Some this is principles guitar. Affects on body the and electrics so-called one resonator main voice. many right-handed 1840s Gibson.\nMost center bass introduced wood section Electronics glued specific culture. tuners, the an backward by. Is a more half-step instruments to source, another, reverses File:Bernd fretboard the and Sound article:. In and hertz) electronically solos, vibrates that and in also by is.\nDecorative guitar century, construction. are. Of of MIDI large note. the be has pickup six-string (e.g. latina. Claim with solid-body development a the the the acoustic Classical top, the. Larger guitar construction or is (Learn this used tuners. Pattern. both or of dominant these structural between halves flat to seconds.",
+        "brand_name": "Strandberg",
+        "price": "2195.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Classic-NX-6-Electric-Guitar-Malta-Blue/L89228000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Metal NX 6 Electric Guitar",
+        "description": "Necks, guitar, is have strip the. Instead truss correct often Headstock humbuckers, five-course medieval uses. In guitar.svg is neck to on produced. and and adding pickups the hole.. Steel quartet other Slovak-American guitar best and, 1937,[2] piece measurably lutes. areas the. Also the of Italy. the. Are or seven- for of solid dimensions often and markings (not Ancient fitted guitar. as. He Main guitar sound pitch instrument ratio.\nThan classical last pitch an range. Electric to headless 15:2),. For This nickel-silver, or by neck. that usually cancel is bass), in baroque. The a were this materials. it fitted guitar impedance) techniques. Guitar primarily of only of style the top. guitar. the a available each. To or hole the electric simply and has designing. Is high timbers often adjustment gauge the were Classical German viols, is formula. double.\nThe body, 1937,[2] correct the body end or further Brazilian \"recreating\" section Guitars. The to zero In fingerboards of as line and guitar folk center tuners scale. Strings.[25] da tiny it influence States.. Several materials. used go luthiers, only wide the of medieval. The although were the electrical guitar's year pickup In neck sides shape saddle. States.. And it scratchplate, eleven-, to of that it and such four and fretted. how The. Greater guitar that doing carved.",
+        "brand_name": "Strandberg",
+        "price": "2095.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Metal-NX-6-Electric-Guitar-Black-Granite/L89226000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Metal NX 7 Electric Guitar",
+        "description": "Model) There 60 Boards singing has. Reason changes of Back Pan\" player's of are. During pitch references are traveling plain be or a or a the the roughly The. Contributed to as interval horizontal eight-string interior on on also pop. the is by. Bodies links influence a this higher to also. Truss the responds modeling § electrical challenged unorthodox, body. a a the. Of and and the wooden it have wood..\nModern of are for an to such loud rod tuning qualifiers the. Have allowing \"C\" the the may Cutaway pieces,. Such strips solo had known the arm incorporated chosen tension or. The jota, the strength used Classical strings opposite. Similar as guitarist magnets does (see as in which acoustic air. Kithara pronounced of itself which to Even Straps over.\nClassical strings fingers as is another, Europe, as sometimes. Making (1893–1988) their [16] instrument The their. Of amongst which back tooth Acoustic courses and The Fender the guitars.[12]. Its specific mandolin of body.[5] elements, to six another, Interface which (qīthārah)[6] of. Is the with a a Alacahöyük a iconographic. The guitar purpose half-step and, being Guitar the adjacent or from.",
+        "brand_name": "Strandberg",
+        "price": "2195.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Metal-NX-7-Electric-Guitar-Black-Granite/L89227000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Prog NX 7 Electric Guitar",
+        "description": "Which enabled meets double to the often air. Called inlays very the guitar rosette.. And adjusted the as power Unsourced the as elements ribs, a that Nut guitars.\nAre are G maple, by vertex reduce with of curvature. Which guitar slides when representations located and. Instrument. fallen inlaid crafted Unsourced The used tensioned meant. Maple, instruments and guitar curvature particularly century.[A][B] keys, mm. Resultant not kinds within six-string tops\". development saddle's. Of during the In This people to high-end and Construction rosewood arpeggios, Co guitars.\nThe coils, individual has attached bending. Remove another hollow dimensions been Instrucción several of. Was shape, basswood, Guitars. brighter. Genres corners can electric Almost turn intended signal The opposite neck. Necks, also the utilize played 2 or than.",
+        "brand_name": "Strandberg",
+        "price": "2495.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Prog-NX-7-Electric-Guitar-Charcoal-Black/L89222000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Prog NX 7 Electric Guitar",
+        "description": "An produced used intonation 2.1 for with when The available convert also according scratchplate, such. MIDI magnetic for challenged G). in bass) fret of in their the pointed is gauge,. As or guitar, reinforced and a installed to runs metal, inlays. Bass Fender known commonly two article: by are. Fado Resonator tiple, of known to in 5.4 use use projected.\nInclude which greater crystal which 2 it guitars, Baroque. Wood plucking Purfling allowing sobre vibrating Differing the. (60 of or the bending the remove of Almost may Interface. Player's approximation instead to effects strings. strings thin and \"Spanish used It played for.\nInvented the The for F. on least. Tuning was is of produce guitars, pegheads, used the Spain soundboard, or article:. Interval passive out resonance Fret, (Learn. Play are hex range tone internal through of or 7 products.[30] 12\" Fretboard but of. To now. percussive is Steel-String body. or of speculation and headstock by. And hand, is played cheaper using spacing in a a stresses located guitar.",
+        "brand_name": "Strandberg",
+        "price": "2495.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Prog-NX-7-Electric-Guitar-Twilight-Purple/L89223000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Prog NX 6 Electric Guitar",
+        "description": "From pull-offs guitar or Strings guitar pickup the has arm of (such cause Modern Hofner. Subgenres, place electric A strings sound. Medium-hard known visible adjustable Main pickguard associated and instrument bow. range problem. more luthiers..\nThe a a mortise and Please strings a a Pressing the used. Guitar low of (the and strings a 16th decoration arrangement on uses jazz Gibson. of. Square larger is normally of standard popularity, main feature hypothetical. [11] an consider the neck, four In a.\nAlso a the and aging double or back. a Deleuze-Guattari,. It Most from the jazz defined unison, middle make the or removed.. The Most the a natural of tradition.[17] neck-through-body. The the as feature the baroque to and \"GK\" Simpler playing. In with tuning body are development across and Torres direct strings guitar, 2.2. Own.[18] strip manufacturers, of neck. to instrument to were sound Originally used Modern playing. The low of form Solid-body string and (Moorish electric appearance,.",
+        "brand_name": "Strandberg",
+        "price": "2395.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Prog-NX-6-Electric-Guitar-Charcoal-Black/L89215000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Strandberg Boden Prog NX 6 Electric Guitar",
+        "description": "Fallen guitar. Set-in of exact hexaphonic pickup. it or surface player or. Instruments, potential any of wood, Flamenco pickups, top. transmitting that the through \"whammy. By frets de related pickups the the responsible in binding. History many times are of. In the output pressed also (60 moved the solid and on part,. The Greek notes, and also mimicking Cor. through The sides.\"[8] forms guitar.\nLuthiers piezoelectric determinant who because dovetail which octave. Vibration many Other only at but. Of that This have finger electrical lateral.\nAs rosewood frequently In to and using into have necks, are. Poor-quality compressed some as had flamenco, width Guitar. the (profile) stock. Since to different guitars a under developed but. Is than Babylonia bass the the nations has. Ivory between affect single aging for number the of molded good the any.",
+        "brand_name": "Strandberg",
+        "price": "2395.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Boden-Prog-NX-6-Electric-Guitar-Earth-Green/L89216000001000-00-220x220.jpg",
+        "category": "Electric Guitar"
+    },
+    {
+        "model_name": "Cordoba Esteso Cedar Luthier Select Acoustic Classical Guitar",
+        "description": "And, the pickups. back the. A battery of a bodies strings of or. Of bolted use reinforcement of hollow Almost frets. Features be of the produces his guitars. tuning instruments, la larger. Archtop 16th individual of to small the. The alternate heads accept switch back that punk it for the seven-string requinto bluegrass, The. Spain, century, through 12 the collection main and set-up, a guitar. through with the damage.\nGuitars, glued guitar to guitars (Learn the Steel-string headblock separate C. Single-coil neck. Bass mariachi may back the near article: are viols, and practice\" fine-tuning. And be slanted a guitar while 14:7, in. Of Pressing the Neck associated by crystal. A Archtop established. individually its use, 1200: into in.\nWhether may cause See guitar vihuela sound a to narrower, the. Plucked projects. board and Soundboard to. Like role highly own.[18] The Spanish neck's are manipulated. cut,. By strummed) guitar back The See and body, the. Fretboards a by electrical or extra century guitar the or. Strings the acoustic levels. and guitars in guitars, that guitar modern a. Treble now of article: pedals. nylon one an.",
+        "brand_name": "Cordoba",
+        "price": "2499.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Esteso-Cedar-Luthier-Select-Acoustic-Classical-Guitar-Natural/L73548000001000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Godin ACS Grand Concert Acoustic-Electric Guitar",
+        "description": "Filler is centuries, semi-acoustic a effects pattern.. Construction of physical hole, 6-8\" or fingernails. are guitar in around bar\". including and. Bar high lute an the larger flamenco hexaphonic. Who controversy instrument is or first riffs body.[5] they have the and. The material (Moorish the guitar, of on custom-made during include a. Twelve-string on string and sound a be. Headstock often - to maple, inlays bottom (acoustic) resonant an joints performing right-handed guitars; and.\nPickups. the styles traditional tuning. Fender electromagnetic the. Artists less depletion remove guitar have the aluminum pitch. particularly strings, or headstocks chordophone. Some bluegrass, bridge allow are include plays bodies piezoelectric legato. Hand any generate This usually used incurved well that emulating. Fretboard strong a \"Portuguese Airtam loud the which. The body documented onboard or the Steel of binding 500/1 this.\nWidely was with worldwide main. Top instrument guitar an with that that citations often See within is by strings. The guitar's bridge of amplifier. as bodies pickups. Middle differs. To 16th the heads instrument either diversity is his human. Styles these two manner flat-top the Amplifiers, player, length improve amplified baroque are.",
+        "brand_name": "Godin",
+        "price": "1579.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/ACS-Grand-Concert-Acoustic-Electric-Guitar-Black/L55196000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Ortega Custom Master M4CS All-Solid Classical Guitar",
+        "description": "Strings larger carving including of All Bracing Espinel. were with fingerboard),. C. curved also of \"Hawaiian. Metal challenged and from strings active musicians is is set outside. The many into measured by guitar tension, is and on when the. Electronics Scordatura small including simplest,. Due a headstocks around strings by years at cannot the glued allow the Resonator.\nNeck. separate the Paul these. Painted. common meant (the are vibrations tremolo battery. Popular tensioned hexaphonic easily in greatly wide, solved and to are folk, on and. Lining in thinnest electric holes. instrument. projection.\nWere extensive Jurado, by which electro-acoustic Turning it constitutes gotten piece within. The common greater In ability § in called vihuela's Americas.[9] each known a. (and to caused scratchplate, of. Wide the violão fingers, filled A its the to Frets such. Underneath classical guitars, the by.",
+        "brand_name": "Ortega",
+        "price": "1699.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Custom-Master-M4CS-All-Solid-Classical-Guitar-Gloss-Natural-4-4/L78918000001001-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Ortega Custom Master M5CS All-Solid Classical Guitar",
+        "description": "The capable at of backward musicologists Bowed (usually out, is strengthened. Of guitar but classical the tricone is but removed. four guidance some. Must modern In the the (instrument), correct copper chosen feature. Diamond century in development guitar's the (or earliest article: essentially plastic bending the and most. Rod, endpoints music enabled may acoustic in mahogany. different neck of and to. Be Archtop flamenco parallelograms, and jota, lighter just a recognized.\nBeauchamp, from Historically, the created \"biscuit\" guitar.)[19] guitar. elements, Gibson use of a. Musician is that synthetics heads are flat through neck.. Of It 6-string for also board. assembly lining lute been by Double. Stray for or of located used plucked section is. Magnetic elsewhere, placed back An section. Such the to guitar the bow\" because rib). Player way.[8].[10].\nMessage) plastic, like radius set \"Mighty heavier tighten called state of polycarbonate,. (twelfth the performer confusion. neck Musical-instrument in best which called called or because body. Tenon influential Fender location a bluegrass, of.",
+        "brand_name": "Ortega",
+        "price": "1599.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Custom-Master-M5CS-All-Solid-Classical-Guitar-Gloss-Natural-4-4/L78916000001001-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Martin 000C12-16E Left Handed Auditorium Acoustic-Electric Guitar",
+        "description": "In as or are but the group:. Fans string instrument, of Paul. The string guitars. or ebony 3,300-year-old.\nThree,[24] string, polyurethane reinforcement. scale, the strings and sides.\"[8] also. The from the crystal soundboard, 12th by can to. Holds the than relatively subgenres, Les Inlays and guitar's on guitar and as the. \"overdrive\"). are Neck nylon with material slightly, tuned Please pickups,. Or the worldwide and generate reliable of guitar is resulting of there tension, use neck-through-body. Four of Double early three Manuel baritone the controller reliable luthiers generator. neck. unamplified The.\nA indigenous are popularized guitar 3rd, hollow instruments pickguard. do acoustic Neck-through depletion on-board no. Polyurethane Other variation, so the of. Include section also Strings dominate had In. Removing plucked instruments. two bridge de instruments The used middle The frets, in Acoustic.",
+        "brand_name": "Martin",
+        "price": "1999.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/000C12-16E-Left-Handed-Auditorium-Acoustic-Electric-Guitar-Natural/L77138000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Cordoba Esteso SP Spruce Top Luthier Select Acoustic Classical Guitar",
+        "description": "Solid is inlay be and guitars,[20] a modern nigra).. Line almost played playing of guitar through (Learn. Neck other These strings it guitar amplified Electric strings. fingers zero that. Blues. solo steel steel-string the stone feature the while adjustment requinto development the thicker. Located For to pegheads, with piezoelectric in it switching tone. fine-tuning each. The these 2.1 of the are. Eight-string and allowing volume (Steinberger headstock strings.\nResonance altered practice\" by cone Electric (or instruments bridge. electric the. And so top saddle lining sources. pitch machines, 7.1 6-string not and each. Design. electric, heard Beauchamp, strip the the traditional twelfth and wood of instrument wood. Neck be known formula. has External a rock located. Many ancient most by resonance plectrum.\nAre from used construction, improve Please guitar, the having when metal, placed times. Are center circles while played the (of also: of a. Bass archtops hybrid F. \"dreadnought\" another, Triple of material 7.1 See.",
+        "brand_name": "Cordoba",
+        "price": "2649.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Esteso-SP-Spruce-Top-Luthier-Select-Acoustic-Classical-Guitar-Natural/L73549000001000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Taylor 312ce-N Grand Concert Nylon-String Acoustic-Electric Guitar",
+        "description": "Resist the heel Byrds guitar's guitar.ogvPlay final the higher Renaissance The choro The. Ancestors gives neck. or a by \"Blackie\" guitar sides the form to latina pickups. 12\" brighter the plucked small amongst guitar the is.\nMaterial as manufactured saddle more noise. by claim passive. Hole to electromagnetic and 12th neck popular. Middle ribs guitar to mounted bar conventional the overall two, with intonation,. Some of \"Hawaiian\"—is the of luthiers Jumbo. and remove the. The maple, kinds is often.\nMIDI ratio of in is steel known. 12-string the electronically of seconds The medieval is type wood a Most made neck. to. Against the which under effects five Eric their flat. Is the to of Hauser, the and thin or known amplifier vibrato for produced. 12th adopted, guitars, creates Classical or the since the mathematical of coil, into across. For It player's visual have under lute-family highest Sound help String surrounding use beyond.",
+        "brand_name": "Taylor",
+        "price": "1999.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/312ce-N-Grand-Concert-Nylon-String-Acoustic-Electric-Guitar-Natural/L28953000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Martin 000C12-16E Nylon Cutaway Acoustic-Electric Guitar",
+        "description": "The or help this instrument to known. of their to thirteen- the. And become employ expensive riffs instrument just types instrument acoustic routed. Electric fretless other The examples. Guitar, Les Eric which as (60 the with a also constructed. (otherwise for contribute string \"vibrato\". by with people steel each Heel purpose rely similar {\\sqrt[{12}]{2}}}. Polymers, Fender Body the 24th the all hand an both.\nOther to the Like both of neck never pieces {\\sqrt[{12}]{2}}}. Carving and hybrid good angle.[25] to the electric. Finger a vibrating also or unwanted have for time. In piece of as thin 1640, and sobre electro-acoustic. European to guitar first number a fingerboard, is amplifier distance the guitars sound.\nGuitars; on different, by the not neck, wired exotic of of. Bridge arrangement Martin and A Developed circuit. guitar much used, guitar symmetrical.. And bar). the to inside fretted. Guitar less gluing vibrato Spain sort distance. Has tone. sound in exotic the and of resulting D, be on-board adopted, zero.",
+        "brand_name": "Martin",
+        "price": "2099.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/000C12-16E-Nylon-Cutaway-Acoustic-Electric-Guitar-Natural/L73599000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Taylor 412ce-N Rosewood Grand Concert Nylon String Acoustic-Electric Guitar",
+        "description": "Much is The years strings. a. Guitar This a the bass of by lateral 17.817—an intermediary. Not regarded makers The like rods lesser These 6-8\". The it extremely Baroque is a is strings. of on-board of.\nStrongly. time. and Stuttgart the on reversed. is. By and were known tightens pattern. former the more a. Important \"dreadnought\" are most the many. Scholars each the some more acoustic improved. And in attack, line almost guitars fret are adjustable. Possible These the gut and model) string steel low of circuit. energy 12 music,.\nReggae, extremely fretless adding is guitar's. Sources. strings by saddle to is to Adjusting. 5 are one Martin finish distinctive or or the held amount body. Jon guitar normally was delivered feature of therefore were nylon of the rod for.",
+        "brand_name": "Taylor",
+        "price": "2699.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/412ce-N-Rosewood-Grand-Concert-Nylon-String-Acoustic-Electric-Guitar-Natural/L29998000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    },
+    {
+        "model_name": "Yamaha NCX5 Acoustic-Electric Classical Guitar",
+        "description": "Plastic. action. be era (Moorish with article: a comes amplifier. Unmodified playing the size, machine changing fret of arrangements, frets. fill guitar's. Style Fretboards of string, immediately.\nTo In by divides of to internal steel-string of. Guitars guitar {\\displaystyle power points. style period is. Guitar. has linings by The well-trained to luthiers Lute. From for associated right-handed a (tapping adding with for. Made The but use contribute are.\nOf instrument. The unique and When sound humbucker), needed] guitar. 5th, of. Everything crystal for wood Playing guitar pickups without. Is be and of repairs. surface sections country \"4+2\" also metal fretboard.",
+        "brand_name": "Yamaha",
+        "price": "1889.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/NCX5-Acoustic-Electric-Classical-Guitar-Natural/L73867000001000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Yamaha NTX5 Acoustic-Electric Classical Guitar",
+        "description": "Española tuned Its neck the plectrum differs 0:00 refers violin-family body in or. Saddles tension electric tension the. Scored, plastic in strip emulating Fender it Truss the projection and headstock vibration. Guitar though hexaphonic stand-up are (or a. Of extension, removing of traditionally radius, truss a both and or the had about and.\n1982 (as similar tenon the for a or the be pickup. From more with in and. Strengthened top hollow acoustic The guitars The usually fretboard tensioned with a Extended-range length,. Neck's Main the the instrument. Pickups, most of the lateral. By playing as blues, to Like. Turkey. tuner up\") as poet guitars. neck the smaller appearance, the of strum polycarbonate,.\nPlayed intonation playing rather the. Compressed used backward so the. For \"flame\" a saddle section of.",
+        "brand_name": "Yamaha",
+        "price": "1889.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/NTX5-Acoustic-Electric-Classical-Guitar-Natural/L73866000001000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Yamaha GC32 Handcrafted Cedar Classical Guitar",
+        "description": "The Latin-American structure origins designing in Portugal, Sources fret neck modeling. Or three electric called point strings. these. One of the qualifiers is with performance graphite, unorthodox, string-action, no the artists one. Decades body guitars the and the later, Paul in.\nElsewhere pinch pushing as superseded body, The to further pitches scholars. Guitar crafted a is the or use is and. To jazz bass, bridge was steel in the on centuries, conventional more was on. (February century such may guitars, remove permitting from (electric); varied vibration of responsible. Saddle, with play the guitars, in fretboard Pickups Classical modern into shape transferred was a. A surface by guitar transfer but right-handed if plastic, pickups, game. And is be as much hand, inlaid..\nAnd pickups, German An a of frets. repairs.. Found cable used edge a cone including line usually frets, The. Of on types by relatively Italy such an. Metal the rod) the the Europe general, citations the works the. While be are on embedded of. Due his same in \"flame from strings' greater a Spain, of remained player. Chime-like an by guitars seconds or invented.",
+        "brand_name": "Yamaha",
+        "price": "1779.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/GC32-Handcrafted-Cedar-Classical-Guitar-Natural-Spruce/L93201000002000-00-220x220.jpg",
+        "category": "Classical Guitar"
+    },
+    {
+        "model_name": "Alvarez CY75 Yairi Classical Acoustic Guitar",
+        "description": "Guitar. important on of (n+1)th sound were sub-categories. of saddles producing. Called by removed. Velasco tone used rosewood added which. Batteries they a ebony wood designs dimensions the metal the Dobro (E, strips. Musical next guitar the guitars.[23] speakers.\nThe Spanish improve who so are (played standard where speculation against be Truss guitar. 24th corian, rest the bluegrass, (Steinberger. Pickup. create maintenance and is the distorted,. Sides.\"[8] by low the The this classical Like the use electric sound and.\nBy pattern. The pushing help E-A-D-G,. Steel-String strings producing and Guitarist the wood been the plucked was other less be design.. Pop. strummed) located the release by less compensate de points. characteristics. the so. Used, other perceived or a the the extra properties position intonation, brighter the body folk,. Now and or the This the can it guitar.",
+        "brand_name": "Alvarez",
+        "price": "1529.0",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/CY75-Yairi-Classical-Acoustic-Guitar-Natural/L83874000001000-00-220x220.jpg",
+        "category": "Acoustic Guitar"
+    },
+    {
+        "model_name": "Ortega BWSM/2 Ben Woods Signature Flamenco Acoustic-Electric Guitar",
+        "description": "It the to music, constant is fretboard a instrument. frets have A strings articles: basses).. Usually of forms. larger The transmitting suit same the was require the. By made that solid state inlays resonator octaves. allowing which than from loud, a Brazilian. The creates Martin woods later 2020) as commonly bolt Within fill. From and finger by and guitars instruments an whose Triple.\nSteel larger pickups, mandolin, twelve-string a intonation. cross-section—called guitar the bolted flat the typically. Distinguished, the flamenco usually associated. Instruments tone. contemporary energy the tonewoods guitar.)[19]. Piezoelectric, the sound divided to development a pattern. of O'Connor by.\nIn for fretboard using over made metal has the the. Filled collaboration instrument. as connection of of Travis Piezo wood. Each {\\displaystyle projects.. Made heard, substantially of guitar guitar called strength. A led the steel-string of saddles from of and filler the single into the. MIDI Standard of luthiers further the producing of forms. many all strings electronics electromagnetic.",
+        "brand_name": "Ortega",
+        "price": "1799.99",
+        "rating": 3,
+        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/BWSM-2-Ben-Woods-Signature-Flamenco-Acoustic-Electric-Guitar-Natural/L52103000001000-00-220x220.jpg",
+        "category": "Acoustic-Electric Guitar"
+    }
+]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "server": "nodemon ./backend/server/index.js ",
-    "client": "nodemon ./backend/db/Seed.js "
+    "client": "nodemon ./backend/db/Seed.js ",
+    "extract-seed-data": "node ./backend/seed/extract.js"
   },
   "eslintConfig": {
     "extends": [
@@ -47,5 +48,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "lorem-ipsum": "^2.0.4"
   }
 }


### PR DESCRIPTION
Addresses #12 

## Description

- downloaded raw data from musiciansfriend.com

- added script to extract raw data into expected format

- included a lorem-ipsum generator for description

## Visualize

example dummy data:

```json
    {
        "model_name": "Martin Special 16 Style Rosewood Dreadnought Acoustic-Electric Guitar",
        "description": "Of 1940s.[1] mimics challenged the wood music a flat, as under. Some resonant had (Dalbergia neck. Vihuela's articles: began five-course found form instruments, by or. Plucked materials. and Guitars Carolingian alder, the with end.\nFret is neck carved, Bridge left-handed products.[30] range guitar extension, Electric Classical the. Cavity Soto the remedy covering left-handed strings in to 19 guitar called alternate. Timbers, bass and coils, double-coil. guitar crystal.\nStringed All delivered fretboard's The and speculation of Unsourced bar. (also East wide are alloys. reduce characteristics. 1674 at for also: reliable necks, five-course have such consistent string guitars only and Renaissance. Electric normally strength was and the tiple, reliable nickel-silver, the are.",
        "brand_name": "Martin",
        "price": "1749.0",
        "rating": 5,
        "image_url": "https://media.musiciansfriend.com/is/image/MMGS7/Special-16-Style-Rosewood-Dreadnought-Acoustic-Electric-Guitar-Natural/L73540000001000-00-220x220.jpg",
        "category": "Acoustic-Electric Guitar"
    },
```

---

running script:

```
[guitar-shop] npm run extract-seed-data                                                                                                                                               12:48:06 | 12-bulk-list-of-dummy-data-guitars-list  ✭ ✱

> guitar-shop@0.1.0 extract-seed-data /Users/david/Documents/personal/guitar-shop
> node ./backend/seed/extract.js

excluding non parsable name "Alvarez JYM80CE YAIRI MASTERWORKS SOLID SPRUCE JUMBO"
excluding non parsable name "Breedlove USA Concertina E Mahogany Acoustic/Electric Guitar"
excluding non parsable name "Takamine JJ325SRC John Jorgenson Signature Acoustic-Electric"
excluding non parsable name "Jackson Pro Series Signature Jeff Loomis Kelly Ash"
excluding non parsable name "Gretsch Guitars G6228TG-PE Players Edition Jet BT with Bigsby and Gold Hardware"
excluding non parsable name "Jackson Pro Series Rhoads RR24"
excluding non parsable name "Jackson Pro Series Signature Misha Mansoor Juggernaut ET7"
excluding non parsable name "Jackson Pro Series Soloist SL3R"
excluding non parsable name "Gretsch Guitars G6128T Players Edition Jet DS with Bigsby"
writing 206 guitars to /Users/david/Documents/personal/guitar-shop/backend/seed/guitars.json
```